### PR TITLE
Change "orange-2" for better contrast/readability

### DIFF
--- a/static/style/colors.css
+++ b/static/style/colors.css
@@ -22,7 +22,7 @@
   --red-1: hsl(7 98 56);
   --red-2: hsl(7 92 54);
   --orange-1: hsl(32 98 56);
-  --orange-2: hsl(32 92 54);
+  --orange-2: hsl(33.65deg 100% 47%);
   --blue-1: hsl(198 97 55);
   --blue-2: hsl(198 89 53);
   --green-1: hsl(80 70 51);


### PR DESCRIPTION
I would appreciate if the orange would be changed rather sooner than later because the contrast is too low for my eyes.  

The exact color I propose can be seen as the same color, really.  


But the contrast is already so much better, that we could switch to a lighter, or even white, background.  However, I don't remember why we have a grey, a relatively dark grey actually, as the background.  My guess is because of contrast issues.  🤷 

E.g. PR -> before

<img width="209" height="51" alt="image" src="https://github.com/user-attachments/assets/2ef065f4-cd2a-449f-bb02-08403f856673" />

<img width="203" height="52" alt="image" src="https://github.com/user-attachments/assets/f56301eb-48c1-4072-8328-e9080cbaaeaa" />
 