### PR TITLE
Provide a web url for each release (if possible)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,6 +26,32 @@ function minimalPackage(pkg, stats) {
     platforms: cleanupPlatforms(release.platforms),
   }))
 
+  // For each release, infer a human web URL under key "web"
+  // Rules:
+  // - GitLab: replace any "/-/..." suffix with "/-/tags"
+  // - GitHub:
+  //   https://codeload.github.com/<owner>/<repo>/zip/<tag>
+  //   => https://github.com/<owner>/<repo>/releases/tag/<tag>
+  for (const release of releases) {
+    const url = release.url ?? ''
+    if (url.startsWith('https://gitlab.com/')) {
+      const idx = url.indexOf('/-/')
+      if (idx !== -1) {
+        release.web = url.slice(0, idx) + '/-/tags'
+      }
+    } else if (
+      url.startsWith('https://codeload.github.com/')
+      // check if the version looks like a "branch"-fallback version
+      && !/^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}\.\d{2}$/.test(release.version ?? '')
+    ) {
+      const m = /^https:\/\/codeload\.github\.com\/([^/]+)\/([^/]+)\/zip\/([^/]+)$/.exec(url)
+      if (m) {
+        const [, owner, repo, tag] = m
+        release.web = `https://github.com/${owner}/${repo}/releases/tag/${tag}`
+      }
+    }
+  }
+
   // sort releases by date, newest first
   // secondary by .sublime_text. strip the leading non-digit from that string first, reverse alphabetical
   releases.sort((a, b) => {


### PR DESCRIPTION
Implements #88

For GitLab, it links to the generic tags page, from there you can see release notes and download the source zip.  That is probably enough.  We just don't have enough GitLab packages to justify more, e.g. to really ask the API for the release page if any.  

For GitHub, a simple regex transformation is enough.  GitHub will redirect automatically to the best page in case the tag has no release associated with it.

Bitbucket doesn't have any such site afaik.  