### PR TITLE
Avoid form flicker in slow loading environments

### DIFF
--- a/static/handle_search_url.js
+++ b/static/handle_search_url.js
@@ -7,8 +7,8 @@
 (function () {
   const params = new URLSearchParams(location.search)
   const q = params.get('q')
-  const isListing = !q && params.has('sort')
-  if (!q && !isListing) {
+  const sort = params.get('sort')
+  if (!q && !sort) {
     return
   };
 
@@ -22,8 +22,15 @@
 
   const onDOMContentLoaded = () => {
     // set temporary content that will be replaced after search completes
+    const form = document.forms.search
+    form.style.visibility = 'revert'
     if (q) {
-      document.querySelector('[name=q]').value = q
+      const input = form.elements['q']
+      input.value = q
+    }
+    if (sort) {
+      const select = form.elements['sort']
+      select.value = sort
     }
   }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -23,7 +23,8 @@ html {
   /* while initializing search, hide package listings */
   &.initializing {
     [data-list-target='hideme'],
-    [data-list-target='section'] {
+    [data-list-target='section'],
+    form[name='search'] {
       visibility: hidden;
     }
   }


### PR DESCRIPTION
* Actually hide the form until "DOMContentLoaded" otherwise the placeholder gets rendered resulting in a fast flicker: "Search 1926 packages" -> "label:amxmodx"
* Add support for "sort" param