### PR TITLE
Add ".readme kbd" style

### DIFF
--- a/static/style/readme.css
+++ b/static/style/readme.css
@@ -27,11 +27,11 @@
 
   kbd {
     display: inline-block;
-    border: 1px solid #eaeaea;
+    border: 1px solid var(--background-3);
     border-radius: 6px;
-    line-height: 1.2rem;
-    padding: 0px 3px;
-    box-shadow: inset 0px -1px 0px #adadad;
-    background: #fdfdfd;
+    line-height: 1.4rem;
+    padding: 0px 4px;
+    box-shadow: inset 0px -1px 0px var(--foreground-4);
+    background: var(--highlight);
   }
 }

--- a/static/style/typography.css
+++ b/static/style/typography.css
@@ -15,7 +15,8 @@
   background-position-y: 26px !important;
 }*/
 
-code {
+code,
+kbd {
   font-family: "IBM Plex Mono", monospace;
   font-size: 0.94em;
 }


### PR DESCRIPTION
The exact colors aren't even that important here.  But it turns

<img width="568" height="188" alt="image" src="https://github.com/user-attachments/assets/48e60eb7-260a-4768-91fd-13cbd44d9c85" />

into

<img width="558" height="163" alt="image" src="https://github.com/user-attachments/assets/2bac43e6-d37e-4993-a740-3aadcc9e4b73" />

and that is clearly better.