### PR TITLE
Fix: Treat `pkg.name` as safe string for the title

### DIFF
--- a/packages/package.njk
+++ b/packages/package.njk
@@ -6,7 +6,7 @@ pagination:
   size: 1
   alias: pkg
 eleventyComputed:
-  title: "{{ pkg.name }}"
+  title: "{{ pkg.name | safe }}"
   description: "{{ pkg.description | default('') }}"
 isPackagePage: true
 ---


### PR DESCRIPTION
Fixes #155