### PR TITLE
skip to search doesn't work reliably on detail

### DIFF
--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -1,9 +1,11 @@
 {% import "util/macros.njk" as util %}
 
 <header>
-  <a href="#search-field" class="skip-link">Skip to search</a>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
-  <a href="#footer-links" class="skip-link">Skip to footer links</a>
+  {% if not isPackagePage %}
+    <a href="#search-field" class="message skip-link">Skip to search</a>
+  {% endif %}
+  <a href="#main-content" class="message skip-link">Skip to main content</a>
+  <a href="#footer-links" class="message skip-link">Skip to footer links</a>
 
   <div class="left-side">
     {% set tag = 'h1' if page.url == '/' else 'p' %}


### PR DESCRIPTION
Because it's collapsed into an icon, we can't jump focus in to the search box. This is a cheap way out. Alternatively we skip to the search button. But it's only 2 tabs away anyway, and search isn't the focus feature of the detail page. 