### PR TITLE
make active buttons appear "pressed in"

### DIFF
--- a/static/style/buttons.css
+++ b/static/style/buttons.css
@@ -43,9 +43,17 @@
 
   &.is-active {
     background: var(--background-4);
-    box-shadow: inset 2px 2px 2px var(--background-5);
-    &.is-active:hover {
+    box-shadow: inset 2px 2px 3px rgb(0 0 0 / 0.15);
+    &:hover {
       background: var(--background-3);
+    }
+
+    :root[data-theme='dark'] & {
+      box-shadow: inset 2px 2px 3px rgb(0 0 0 / 0.25);
+      background: var(--background-3);
+      &:hover {
+        background: var(--background-4);
+      }
     }
   }
   &.is-active:hover {

--- a/static/style/colors.css
+++ b/static/style/colors.css
@@ -39,6 +39,7 @@
   --background-2: hsl(214 17% 18%);
   --background-3: hsl(211 14% 30%);
   --background-4: hsl(211 12% 35%);
+  --background-5: hsl(210 11% 40%);
 
   --highlight: hsl(210 14% 46% / 0.16); /* inline code */
 
@@ -54,6 +55,8 @@
   --orange-3: hsl(32 97% 67%);
   --blue-1: hsl(198 88% 51%);
   --blue-2: hsl(198 97% 54%);
+  --blue-3: hsl(198 98% 66%);
   --green-1: hsl(80 67% 47%);
   --green-2: hsl(80 70% 49%);
+  --green-3: hsl(80 72% 58%);
 }

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -86,9 +86,14 @@ ul.stats {
       }
       &.is-active {
         background: var(--blue-2);
-        box-shadow: inset 2px 2px 3px var(--blue-3);
         &:hover {
           background: var(--blue-1);
+        }
+        :root[data-theme='dark'] & {
+          background: var(--blue-1);
+          &:hover {
+            background: var(--blue-2);
+          }
         }
       }
     }
@@ -101,9 +106,14 @@ ul.stats {
       }
       &.is-active {
         background: var(--orange-2);
-        box-shadow: inset 2px 2px 3px var(--orange-3);
         &:hover {
           background: var(--orange-1);
+        }
+        :root[data-theme='dark'] & {
+          background: var(--orange-1);
+          &:hover {
+            background: var(--orange-2);
+          }
         }
       }
     }
@@ -117,9 +127,14 @@ ul.stats {
       }
       &.is-active {
         background: var(--green-2);
-        box-shadow: inset 2px 2px 3px var(--green-3);
         &:hover {
           background: var(--green-1);
+        }
+        :root[data-theme='dark'] & {
+          background: var(--green-1);
+          &:hover {
+            background: var(--green-2);
+          }
         }
       }
     }


### PR DESCRIPTION
A small refinement as I proposed in #139

This uses the metaphor of the buttons being stuck, meaning you can press again to unstick.  It also leaves outlines to just mean "focused". Overall it's just a little more subtle, dare I say sophisticated 😉 

<img width="909" height="146" alt="Scherm­afbeelding 2025-10-15 om 12 36 07" src="https://github.com/user-attachments/assets/665525d4-3ab4-4e43-a8dd-bd4fe71bc59b" />


