### PR TITLE
Switch meaning of "newest" to "first_seen"

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -74,6 +74,7 @@ function basePackage(pkg, stat) {
     author: util.cleanAuthors(pkg.author) ?? [],
     stars: pkg.stars ?? 0,
     installed: stat?.installs?.totals ?? 0,
+    first_seen: pkg.first_seen,
     created_at: pkg.created_at,
     last_modified: pkg.last_modified,
     archived_at: pkg.archived_at,
@@ -221,7 +222,7 @@ export default function (eleventyConfig) {
     return all_packages.filter(pkg => !pkg.removed).map(pkg => ({
       ...basePackage(pkg, stats[pkg.name]),
     })).sort((a, b) => {
-      return new Date(b.created_at ?? '1970-01-01 00:00:00') - new Date(a.created_at ?? '1970-01-01 00:00:00')
+      return new Date(b.first_seen ?? '1970-01-01 00:00:00') - new Date(a.first_seen ?? '1970-01-01 00:00:00')
     }).slice(0, 9)
   })
 

--- a/search/index.json.njk
+++ b/search/index.json.njk
@@ -10,6 +10,7 @@ permalink: "/search/index.json"
     "author": "{{ pkg.author | join(', ') }}",
     "stars": "{{ pkg.stars }}",
     "installed": "{{ pkg.installed }}",
+    "first_seen": "{{ pkg.first_seen | timestamp }}",
     "created_at": "{{ pkg.created_at | timestamp }}",
     "last_modified": "{{ pkg.last_modified | timestamp }}",
     {%- if pkg.doa -%}

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -46,6 +46,7 @@ function createMinisearchInstance(MiniSearch) {
       'author',
       'stars',
       'installed',
+      'first_seen',
       'created_at',
       'last_modified',
       'archived_at',

--- a/static/module/recent-pager.js
+++ b/static/module/recent-pager.js
@@ -446,8 +446,8 @@ const pagerConfigs = [
   {
     section: 'newest',
     options: {
-      queryParam: 'created_after',
-      timestampField: 'created_at',
+      queryParam: 'seen_after',
+      timestampField: 'first_seen',
       manageMainContent: true,
     },
   },

--- a/static/module/sort.js
+++ b/static/module/sort.js
@@ -32,15 +32,15 @@ export class Sort {
 
       case 'newest':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.created_at) || 0
-          const B = parseInt(b.created_at) || 0
+          const A = parseInt(a.first_seen) || 0
+          const B = parseInt(b.first_seen) || 0
           return B - A // High to low
         })
 
       case 'oldest':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.created_at) || 0
-          const B = parseInt(b.created_at) || 0
+          const A = parseInt(a.first_seen) || 0
+          const B = parseInt(b.first_seen) || 0
           return A - B // Low to high
         })
 


### PR DESCRIPTION
After ingesting all the old "first_seen" data into "workspace.json", switch from "created_at" to "first_seen".

This makes the newest section on the homeland and the list by newest page match the order found on pc.io.

Also, typical:  I create a package actually a year before I eventually decide to publish it on packagecontrol.  Such a package would never appear on the homepage.

"first_seen" has roughly the meaning "registered_at" but we don't add that to the "registry.json" during registration, although it is hard to recreate on data loss.  🤷 On the package details page we still show "Created at ...".