### PR TITLE
Fix hover over "active" (pressed) grey button

### DIFF
--- a/static/style/buttons.css
+++ b/static/style/buttons.css
@@ -56,9 +56,6 @@
       }
     }
   }
-  &.is-active:hover {
-    background: var(--background-4);
-  }
 
   &:focus-visible {
     outline: 2px solid var(--orange-1);


### PR DESCRIPTION
Specificity of `&.is-active:hover` beats `&.is-active &:hover` and that is probably not what we wanted.