### PR TITLE
Fix title for removed packages

### DIFF
--- a/search/index.json.njk
+++ b/search/index.json.njk
@@ -16,7 +16,7 @@ permalink: "/search/index.json"
     {%- if pkg.doa -%}
       "doa": true,
     {%- elif pkg.removed -%}
-      "removed": true,
+      "removed": "{{ pkg.removed | timestamp }}",
     {%- elif pkg.archived_at -%}
       "archived_at": "{{ pkg.archived_at | timestamp }}",
     {%- endif %}


### PR DESCRIPTION
Fixes the title displayed for removed packages.

<img width="1073" height="111" alt="Captura de pantalla 2025-10-19 a las 21 46 22" src="https://github.com/user-attachments/assets/7547ca34-55fc-47ce-8381-dc8dc66bd6f8" />
