### PR TITLE
Fix: count in potential search parameters in `initialPath`

### DIFF
--- a/static/module/list.js
+++ b/static/module/list.js
@@ -41,7 +41,7 @@ export class List {
   hideme = document.querySelectorAll(`[${this.attr}='hideme']`)
 
   constructor() {
-    this.initialPath = window.location.pathname
+    this.initialPath = `${window.location.pathname}${window.location.search}`
   }
 
   setCounter(count = null) {


### PR DESCRIPTION
Fixes #169

Since the homepage has a recent-pager which puts its state in the URL, e.g. ".../?updated_after=1686737924", reverting the search needs to account for that as well.

Before the change we would revert to the root path ("/").