### PR TITLE
Fix: On load, prevent any unnecessary `history.push`

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -95,21 +95,24 @@ const updateFilterButtonStates = (query) => {
 
 list.setFilterStateUpdater(updateFilterButtonStates)
 
-const syncFromUrl = () => {
+const syncFromUrl = ({ initialPageLoad = false }) => {
   const urlParams = new URLSearchParams(window.location.search)
   const query = urlParams.get('q') || ''
   const sortBy = urlParams.get('sort')
   const page = parseInt(urlParams.get('page')) || 1
   const effectiveSortBy = sortBy ?? 'relevance'
 
+  if (initialPageLoad && !query && !sortBy) {
+    return
+  }
+
   input.value = query
   sortSelect.value = effectiveSortBy
-
   list.goSearch(query, effectiveSortBy, page)
 }
 
 // Handle initial page load
-syncFromUrl()
+syncFromUrl({ initialPageLoad: true })
 
 const handleInput = () => {
   const query = input.value


### PR DESCRIPTION
Fixes #170

Abort `syncFromUrl` early on page-load if the URL indicates no search.
In that case we would basically run into `revertToNormal` which is the
loading state anyway.  But before that we risk a `history.push` if
`currentPath !== target` (in `goSearch`).

The culprit here is that the currentPath can have additional state on
it coming from the `recent-pager` but the URL we compare to never has.
And that is a bug because `goSearch` now thinks we go to a new page.

Actually we have two ways of preventing a `pushState` here:  (a) by a
switch or (b) by making `currentPath !== target` smarter.

We choose (a) and don't even enter `goSearch`.