### PR TITLE
Simplify library platforms

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -277,9 +277,14 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addCollection('libraries', () => {
     const libraries = JSON.parse(fs.readFileSync('libraries.json', 'utf8'))
-    return libraries.libraries.map(lib => ({
-      ...normalizedLib(lib),
-    }))
+    const dataset = util.collectPlatformDataset(libraries.libraries)
+    return libraries.libraries.map((lib) => {
+      const base = normalizedLib(lib)
+      return {
+        ...base,
+        platforms: util.simplifyPlatforms(dataset, base.platforms),
+      }
+    })
   })
 
   eleventyConfig.addGlobalData('built', () => {

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -26,6 +26,68 @@ export function dedupePlatforms(releases) {
 }
 
 /**
+ * Build the platform variant dataset over all libraries.
+ * Input: array of libraries, each with releases[].platforms
+ * Output: { windows: Set<string>, linux: Set<string>, osx: Set<string> }
+ */
+export function collectPlatformDataset(libraries) {
+  const variantsByOs = {}
+  for (const lib of libraries || []) {
+    for (const rel of lib.releases || []) {
+      for (const p of rel.platforms || []) {
+        const m = /^(.+?)-(.+)$/i.exec(p)
+        if (m) {
+          const os = m[1].toLowerCase()
+          const label = m[2].toLowerCase()
+          if (!variantsByOs[os]) variantsByOs[os] = new Set()
+          variantsByOs[os].add(label)
+        }
+      }
+    }
+  }
+  return variantsByOs
+}
+
+/**
+ * Simplify a library's platform list using the global dataset.
+ * - If the library contains all known variants for an OS, collapse to base token (windows/linux/osx).
+ * - If, after collapsing, it contains all three base tokens, return [] to hide labels.
+ */
+export function simplifyPlatforms(dataset, platforms) {
+  const hasAll = (libSet, datasetSet) => {
+    for (const v of datasetSet)
+      if (!libSet.has(v))
+        return false
+    return true
+  }
+
+  const platformVariants = {}
+  for (const p of platforms) {
+    const m = /^(.+?)-(.+)$/i.exec(p)
+    if (m) {
+      const os = m[1].toLowerCase()
+      const variant = m[2].toLowerCase()
+      if (!platformVariants[os]) platformVariants[os] = new Set()
+      platformVariants[os].add(variant)
+    }
+  }
+
+  let result = new Set()
+  for (const [os, variants] of Object.entries(platformVariants)) {
+    if (hasAll(variants, dataset[os]))
+      result.add(os)
+    else
+      variants.forEach(variant => result.add(`${os}-${variant}`))
+  }
+
+  if (['windows', 'linux', 'osx'].every(os => result.has(os))) {
+    return []
+  }
+
+  return Array.from(result)
+}
+
+/**
  * Author can be string or array: convert to all arrays.
  */
 export function cleanAuthors(author) {
@@ -225,6 +287,53 @@ if (import.meta.vitest) {
       ['n/a', 0],
     ])('parseSublimeTextMin(%j) -> %j', (input, expected) => {
       expect(parseSublimeTextMin(input)).toBe(expected)
+    })
+  })
+
+  describe('collectPlatformDataset + simplifyPlatforms (libraries)', () => {
+    const libraries = [
+      {
+        releases: [
+          { platforms: ['windows-x32', 'windows-x64'] },
+          { platforms: ['linux-x32'] },
+        ],
+      },
+      {
+        releases: [
+          { platforms: ['linux-x64'] },
+          { platforms: ['osx-x64'] },
+        ],
+      },
+    ]
+
+    it('collects global variant sets per OS', () => {
+      const ds = collectPlatformDataset(libraries)
+      expect(Array.from(ds.windows).sort()).toEqual(['x32', 'x64'])
+      expect(Array.from(ds.linux).sort()).toEqual(['x32', 'x64'])
+      expect(Array.from(ds.osx).sort()).toEqual(['x64'])
+    })
+
+    it('collapses to base OS only when all variants are present for that OS', () => {
+      const ds = collectPlatformDataset(libraries)
+
+      // Has both windows variants -> collapse to 'windows'
+      expect(simplifyPlatforms(ds, ['windows-x32', 'windows-x64'])).toEqual(['windows'])
+
+      // Missing one windows variant -> do not collapse
+      expect(simplifyPlatforms(ds, ['windows-x64'])).toEqual(['windows-x64'])
+
+      // Linux has x32 and x64 in dataset; this lib has both -> collapse
+      expect(simplifyPlatforms(ds, ['linux-x32', 'linux-x64'])).toEqual(['linux'])
+
+      // OSX dataset has only x64; having x64 means "all known" -> collapse
+      expect(simplifyPlatforms(ds, ['osx-x64'])).toEqual(['osx'])
+    })
+
+    it('hides labels when all three base OS tokens are present', () => {
+      const ds = collectPlatformDataset(libraries)
+      expect(simplifyPlatforms(ds, ['windows-x32', 'windows-x64', 'linux-x32', 'linux-x64', 'osx-x64']))
+        .toEqual([])
+      expect(simplifyPlatforms(ds, ['windows', 'linux', 'osx'])).toEqual([])
     })
   })
 }


### PR DESCRIPTION
This applies to the libraries sub-page.  

E.g. simplify "windows-32, windows-64" platform labels => "windows".