### PR TITLE
Remove trailing slashes from the URLs

### DIFF
--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -16,12 +16,12 @@
   <nav>
     <a id="footer-links" href="https://docs.sublimetext.io/guide/package-control/submitting.html">Submit your package</a>
     <a href="https://docs.sublimetext.io/guide/package-control/usage.html">Using package control</a>
-    {% if page.url == "/libraries/" %}
+    {% if page.url == "/libraries" %}
       <a href="/">Packages</a>
     {% else %}
       <a href="/libraries">Libraries</a>
     {% endif %}
-    {% if page.url == "/labels/" %}
+    {% if page.url == "/labels" %}
       <a href="/">Packages</a>
     {% else %}
       <a href="/labels">Labels</a>

--- a/browse/new/rss.njk
+++ b/browse/new/rss.njk
@@ -18,7 +18,7 @@ eleventyAllowMissingExtension: true
       <author>{{ pkg.author | join(', ') }}</author>
       <description>{{ pkg.description | default('') | escape }}</description>
       <pubDate>{{ pkg.first_seen }}</pubDate>
-      <link>{{ site.origin }}/packages/{{ pkg.name | urlencode }}/</link>
+      <link>{{ site.origin }}/packages/{{ pkg.name | urlencode }}</link>
       <guid>{{ pkg.guid }}</guid>
     </item>
 {% endfor %}

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -296,6 +296,19 @@ export default function (eleventyConfig) {
     devOrigin,
   })
 
+  // Default permalink: output files with their extension (e.g., /page.html)
+  // Can be overridden per-template (e.g., RSS feed or JSON endpoints)
+  eleventyConfig.addGlobalData('permalink', () => {
+    return data => `${data.page.filePathStem}.${data.page.outputFileExtension}`
+  })
+
+  // Remove .html from computed page.url to create extensionless URLs
+  eleventyConfig.addUrlTransform((page) => {
+    if (page.url && page.url.endsWith('.html')) {
+      return page.url.slice(0, -1 * '.html'.length)
+    }
+  })
+
   // Register all named exports from external module as filters
   for (const [name, fn] of Object.entries(filters)) {
     eleventyConfig.addFilter(name, fn)

--- a/packages/macros.njk
+++ b/packages/macros.njk
@@ -114,7 +114,7 @@
 {% macro card(pkg, mark_as_main=false) %}
   <div class="card">
     <h3>
-      <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}/">
+      <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
         {{- pkg.name -}}
       </a>
     </h3>

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -1,6 +1,6 @@
 ---
 layout: layout.njk
-permalink: "packages/{{ pkg.name | safe }}/"
+permalink: "packages/{{ pkg.name | safe }}.html"
 pagination:
   data: collections.packages
   size: 1

--- a/search/index.json.njk
+++ b/search/index.json.njk
@@ -22,7 +22,7 @@ permalink: "/search/index.json"
     {%- endif %}
     "platforms": "{{ pkg.platforms | default([]) | join(",") }}",
     "labels": "{{ pkg.labels | default([]) | join(",") }}",
-    "permalink": "/packages/{{ pkg.name | urlencode }}/"
+    "permalink": "/packages/{{ pkg.name | urlencode }}"
   }{{ "," if not loop.last }}
 {%- endfor %}
 ]


### PR DESCRIPTION
Fixes #190

Follows the recipe at https://www.11ty.dev/docs/permalinks/#remove-trailing-slashes