### PR TITLE
Do not split the tokens on `#+` to support e.g. "c#"

### DIFF
--- a/static/labels.js
+++ b/static/labels.js
@@ -1,5 +1,6 @@
 import minisearch from 'https://cdn.jsdelivr.net/npm/minisearch@7.1.2/+esm'
 import { SimpleSearch } from './module/simplesearch.js'
+import { customTokenizer } from './module/minisearch.js'
 
 /**
  * Simplified search features on the labels listing page.
@@ -32,6 +33,7 @@ cards.forEach((card) => {
 const minisrch = new minisearch({
   idField: 'name',
   fields: ['name'],
+  tokenize: customTokenizer,
   storeFields: ['name'],
   searchOptions: {
     prefix: true,

--- a/static/libs.js
+++ b/static/libs.js
@@ -1,5 +1,6 @@
 import minisearch from 'https://cdn.jsdelivr.net/npm/minisearch@7.1.2/+esm'
 import { SimpleSearch } from './module/simplesearch.js'
+import { customTokenizer } from './module/minisearch.js'
 
 /**
  * Simplified search features on the library listing page.
@@ -36,6 +37,7 @@ const data = Array.from(cards, (card) => {
 const minisrch = new minisearch({
   idField: 'name',
   fields: ['name', 'author', 'description', 'platforms'],
+  tokenize: customTokenizer,
   storeFields: ['name', 'author', 'platforms'],
   searchOptions: {
     boost: { author: 2 },

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -6,10 +6,10 @@ const VARIANT_REPLACEMENTS = [
 
 let SPLIT_TOKEN_REGEX
 try {
-  SPLIT_TOKEN_REGEX = new RegExp('[^\\p{L}\\p{N}]+', 'u')
+  SPLIT_TOKEN_REGEX = new RegExp('[^\\p{L}\\p{N}#+]+', 'u')
 } catch {
   // Fallback to ASCII-only splitting when Unicode property escapes are unavailable.
-  SPLIT_TOKEN_REGEX = /[^a-z0-9]+/i
+  SPLIT_TOKEN_REGEX = /[^a-z0-9#+]+/i
 }
 
 function normalizeToken(token) {

--- a/static/module/minisearch.test.js
+++ b/static/module/minisearch.test.js
@@ -150,4 +150,55 @@ describe('MiniSearch.search', () => {
       expect(names).toContain('中文工具')
     })
   })
+
+  describe('Special handling of c++ and c#', () => {
+    let minisrch
+
+    const cPackages = [
+      {
+        name: 'SharpTool',
+        description: 'C# utilities for developers',
+        author: 'Sharp Co',
+        platforms: ['windows'],
+        labels: ['c#', 'dotnet'],
+      },
+      {
+        name: 'PlusPlusHelper',
+        description: 'C++ utilities for developers',
+        author: 'Plus Co',
+        platforms: ['linux'],
+        labels: ['c++'],
+      },
+      {
+        name: 'SeaLangHelper',
+        description: 'C language support tools',
+        author: 'Sea Co',
+        platforms: ['linux'],
+        labels: ['c'],
+      },
+    ]
+
+    beforeAll(() => {
+      minisrch = createSearch(cPackages)
+    })
+
+    it('tokenizes programming terms containing special characters as whole tokens', () => {
+      const tokens = customTokenizer('c# c++ f# developer')
+      expect(tokens).toEqual(expect.arrayContaining(['c#', 'c++', 'f#']))
+    })
+
+    it('returns only C# packages when searching for c#', () => {
+      const results = minisrch.search('c#')
+      const names = results.map(entry => entry.name)
+      expect(names).toContain('SharpTool')
+      expect(names).not.toContain('SeaLangHelper')
+    })
+
+    it('returns only C++ packages when searching for c++', () => {
+      const results = minisrch.search('c++')
+      const names = results.map(entry => entry.name)
+      expect(names).toContain('PlusPlusHelper')
+      expect(names).not.toContain('SeaLangHelper')
+    })
+  })
 })

--- a/static/module/search.test.js
+++ b/static/module/search.test.js
@@ -372,3 +372,56 @@ describe('Search.search', () => {
     })
   })
 })
+
+describe('Search integration with MiniSearch', () => {
+  const data = [
+    {
+      name: 'SharpTool',
+      description: 'C# utilities for developers',
+      author: 'Sharp Co',
+      platforms: ['windows'],
+      labels: ['c#', 'dotnet'],
+    },
+    {
+      name: 'PlusPlusHelper',
+      description: 'C++ utilities for developers',
+      author: 'Plus Co',
+      platforms: ['linux'],
+      labels: ['c++'],
+    },
+    {
+      name: 'SeaLangHelper',
+      description: 'C language support tools',
+      author: 'Sea Co',
+      platforms: ['linux'],
+      labels: ['c'],
+    },
+  ]
+
+  const minisrch = createMinisearch(MiniSearch, data)
+  const search = new Search(minisrch)
+
+  it('matches exact C# label filters without returning plain C labels', () => {
+    const results = search.search('label:"c#"')
+    const names = results.map(entry => entry.name)
+    expect(names).toContain('SharpTool')
+    expect(names).not.toContain('SeaLangHelper')
+    expect(names).not.toContain('PlusPlusHelper')
+  })
+
+  it('matches C++ label filters without returning other C variants', () => {
+    const results = search.search('label:"c++"')
+    const names = results.map(entry => entry.name)
+    expect(names).toContain('PlusPlusHelper')
+    expect(names).not.toContain('SharpTool')
+    expect(names).not.toContain('SeaLangHelper')
+  })
+
+  it('supports free text searches for programming terms containing punctuation', () => {
+    const results = search.search('c++')
+    const names = results.map(entry => entry.name)
+    expect(names).toContain('PlusPlusHelper')
+    expect(names).not.toContain('SharpTool')
+    expect(names).not.toContain('SeaLangHelper')
+  })
+})


### PR DESCRIPTION
Fixes #202

This first enhances the custom tokenizer, but then also uses it for labels and libraries. 