### PR TITLE
Preserve the search term case in the URL

### DIFF
--- a/static/module/list.js
+++ b/static/module/list.js
@@ -158,7 +158,7 @@ export class List {
 
     this.filterStateUpdater?.(value)
 
-    const query = value.toLowerCase().trim()
+    const query = value.trim()
     const hasQuery = query.length > 0
     const usingWildcard = !hasQuery && sortBy !== 'relevance'
 


### PR DESCRIPTION
Fixes #203

Since the URL is our state-store it is important that the input value and the URL actually match because we restore the input value when refreshing.