### PR TITLE
Fix search results header positions for small screens

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -254,6 +254,11 @@ section {
   > h2 {
     margin: 0;
     padding-top: 0;
+
+    @media (width <= 400px) {
+      font-size: 22px;
+      margin-bottom: -5px;
+    }
   }
 
   .pager-page-indicator,
@@ -268,8 +273,8 @@ section {
       visibility: hidden;
     }
 
-    @media (max-width: 479px) {
-      padding-bottom: 10px;
+    @media (width <= 400px) {
+      padding-bottom: 6px;
     }
   }
 
@@ -279,7 +284,7 @@ section {
     }
   }
 
-  @media (max-width: 1050px) {
+  @media (width <= 1050px) {
     /* Center the .pager-page-indicator */
     .pager-range-indicator[hidden] {
         display: none;


### PR DESCRIPTION
To avoid wrapping we use a smaller h2 font-size on really small screens. 

The `max-width: 479px` mod was a mistake copied from the recent-pager. Since I refactored the positioning the padding-bottom hack is not necessary anymore.