### PR TITLE
Special case codeberg and gitlab readme loading

### DIFF
--- a/static/readme.js
+++ b/static/readme.js
@@ -45,7 +45,7 @@ else {
       }
       else {
         target.style.textAlign = 'center'
-        target.innerHTML = '😒<br>the readme failed to load.'
+        target.innerHTML = '😒<br>The readme failed to load.'
       }
     })
 }


### PR DESCRIPTION


Both hubs actually do not allow (hint: CORS) loading the README in the
browser, hence, still be optimistic and try a load, but on failure just
hide the readme section.

Closes #204