### PR TITLE
Provide ".sublime-package" download links

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -23,7 +23,7 @@
   {% endif %}
 
   ·
-  <a class="download" href="{{ version.url }}" title="Download">
+  <a class="download" href="{{ version.download_url or version.url }}" title="Download">
     {{ util.icon('zip') }}
   </a>
 

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -4,6 +4,14 @@ import { minify } from 'terser'
 import * as util from './eleventy.util.mjs'
 import * as filters from './eleventy.filters.mjs'
 
+const repackagerSite = 'https://repackager.sublimetext.io'
+const supportedRepackagerHosts = [
+  'https://codeload.github.com/',
+  'https://bitbucket.org/',
+  'https://codelab.org/',
+  'https://gitlab.com/',
+]
+
 function basePackage(pkg, stat) {
   // Create a new array of releases with cleaned platforms
   const releases = (pkg.releases || []).map(release => ({
@@ -35,6 +43,11 @@ function basePackage(pkg, stat) {
         const tag_ = encodeURIComponent(tag)
         release.web = `https://github.com/${owner}/${repo}/releases/tag/${tag_}`
       }
+    }
+    // Provide repackager links if possible
+    if (supportedRepackagerHosts.some(n => url.startsWith(n))) {
+      const encodedName = encodeURIComponent(pkg.name)
+      release.download_url = `${repackagerSite}/?url=${url}&name=${encodedName}`
     }
   }
 


### PR DESCRIPTION
For the `supportedRepackagerHosts` compute correct `download_url`s and link to them instead of the raw release urls.

This has the benefit that the user actually downloads a working package, ready to be dropped into the Installed Packages folder.

The repackager service suggest the correct filename and file extension. If it suggest ".zip", the package is a no-package package and must be unzipped into the Packages folder instead.