### PR TITLE
Style "More/Other releases" section

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -11,11 +11,11 @@
   {%- endif -%}
 {%- endmacro %}
 
-{% macro release(version) %}
+{% macro release(version, omit_requirements=false) %}
   <a class="download" href="{{ version.download_url or version.url }}" title="Download package">{{ version.version }}</a>
 
   {% set requirement = version.sublime_text | format_requirement %}
-  {% if requirement != "*" %}
+  {% if not omit_requirements and requirement and requirement != "*" %}
     <span class="requirement" title="Required ST build">({{ requirement }})</span>
   {% endif %}
 

--- a/_includes/packages/releases.njk
+++ b/_includes/packages/releases.njk
@@ -14,11 +14,23 @@
 
 {% if pkg.otherReleases and pkg.otherReleases | length > 0 %}
   <details class="other-releases">
-    <summary>Other releases</summary>
+    <summary>More</summary>
     <ul>
+      {% set last_build = '' %}
       {% for version in pkg.otherReleases %}
+        {% set raw_build = version.sublime_text %}
+        {% set build = '' %}
+        {% if raw_build and raw_build != '*' %}
+          {% set build = raw_build | format_requirement %}
+        {% endif %}
         <li>
-          {{ pack.release(version) }}
+          {% if build and build != last_build %}
+            <span class="requirement" title="Required ST build">({{ build }})</span>
+            {% set last_build = build %}
+          {% elseif last_build %}
+            <br>
+          {% endif %}
+          {{ pack.release(version, omit_requirements=true) }}
         </li>
       {% endfor %}
     </ul>

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -87,6 +87,42 @@ ul.stats {
   }
 }
 
+.other-releases {
+
+  summary {
+    margin-bottom: 0px;
+    padding: 0;
+    outline-offset: 8px;
+    margin-top: 28px;
+    color: var(--foreground-1);
+    outline-color: var(--orange-1);
+  }
+
+  ul {
+    list-style: none;
+    display: flex;
+    gap: 1.4rem;
+    overflow-x: auto;
+    margin: 0;
+    padding-left: 0;
+    padding-top: 0;
+
+
+  li {
+      margin: 0px 0 16px 0;
+      min-width: max-content;
+      padding: 0px 8px 2px;
+      border-radius: 3px;
+      margin-left: -6px;
+      margin-right: 6px;
+
+      .requirement {
+        display: block;
+      }
+    }
+  }
+}
+
 .labels {
   a,
   span {


### PR DESCRIPTION
Fixes #226

The details/summary section to show "Other releases" basically only had the stock design.  Let's change that.

Test with e.g. ["Theme - Monkai"](http://localhost:8080/packages/Theme%20-%20Monokai%20Pro) as that has a lot of "other"/old releases in the workspace.json.  




