### PR TITLE
Mark outdated, st2-only and st3-only, packages

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -60,7 +60,7 @@
               {{ label }}
             </a>
           {% else %}
-            <a class="button label" href="/?q={{ q }}">
+            <a class="button label{{ ' outdated' if label == '<ST3' }}{{ ' st3_only' if label == 'ST3' }}" href="/?q={{ q }}">
               {{ label }}
             </a>
           {% endif %}
@@ -111,7 +111,7 @@
 {% endmacro %}
 
 {% macro card(pkg, mark_as_main=false) %}
-  <div class="card">
+  <div class="card{{ ' dimmed' if pkg.outdated }}">
     <h3>
       <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
         {{- pkg.name -}}

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -125,6 +125,9 @@ function basePackage(pkg, stat) {
   const supportsModernSublime = releases.some((release) => {
     return util.parseSublimeTextMin(release.sublime_text) >= 3000
   })
+  const doesNotSupportNewestSublime = releases.every((release) => {
+    return util.parseSublimeTextMax(release.sublime_text) < 4000
+  })
 
   // For each release, infer a human web URL under key "web"
   // Rules:
@@ -187,6 +190,10 @@ function basePackage(pkg, stat) {
     }
   }
 
+  const labels = pkg.labels?.slice() ?? []
+  if (!supportsModernSublime) labels.push('<ST3')
+  if (supportsModernSublime && doesNotSupportNewestSublime) labels.push('ST3')
+
   return {
     name: pkg.name,
     author: util.cleanAuthors(pkg.author) ?? [],
@@ -200,9 +207,10 @@ function basePackage(pkg, stat) {
     doa: pkg.removed && !pkg.first_seen,
     releases: dedupedReleases,
     otherReleases,
-    labels: pkg.labels,
+    labels: labels,
     platforms: util.dedupePlatforms(releases),
     outdated: !supportsModernSublime,
+    st3_only: supportsModernSublime && doesNotSupportNewestSublime,
   }
 }
 

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -179,6 +179,40 @@ export function parseSublimeTextMin(selector) {
   return Number.isFinite(n) ? n : 0
 }
 
+export function parseSublimeTextMax(selector) {
+  if (typeof selector !== 'string') {
+    return Infinity
+  }
+  const s = selector.replace(/\s+/g, '')
+  if (s === '' || s === '*') {
+    return Infinity
+  }
+
+  const rangeIdx = s.indexOf('-')
+  if (rangeIdx !== -1) {
+    const right = s.slice(rangeIdx + 1)
+    const n = parseInt(right, 10)
+    return Number.isFinite(n) ? n : Infinity
+  }
+
+  if (s.startsWith('<=')) {
+    const n = parseInt(s.slice(2), 10)
+    return Number.isFinite(n) ? n : Infinity
+  }
+  if (s.startsWith('<')) {
+    const n = parseInt(s.slice(1), 10)
+    return Number.isFinite(n) ? Math.max(0, n - 1) : Infinity
+  }
+  if (s.startsWith('>=')) {
+    return Infinity
+  }
+  if (s.startsWith('>')) {
+    return Infinity
+  }
+  const n = parseInt(s, 10)
+  return Number.isFinite(n) ? n : Infinity
+}
+
 /**
  * Find the last git commit hash.
  * Only executes in production builds to avoid overhead and issues when git is unavailable.
@@ -287,6 +321,27 @@ if (import.meta.vitest) {
       ['n/a', 0],
     ])('parseSublimeTextMin(%j) -> %j', (input, expected) => {
       expect(parseSublimeTextMin(input)).toBe(expected)
+    })
+  })
+
+  describe('parseSublimeTextMax', () => {
+    it.each([
+      [null, Infinity],
+      ['', Infinity],
+      ['*', Infinity],
+      ['  *  ', Infinity],
+      ['3092', 3092],
+      ['3092 - 4000', 4000],
+      ['3092-4000', 4000],
+      ['<3092', 3091],
+      ['<=3092', 3092],
+      ['>3092', Infinity],
+      ['>=3092', Infinity],
+      [' >=  4075 ', Infinity],
+      ['>  4075', Infinity],
+      ['n/a', Infinity],
+    ])('parseSublimeTextMax(%j) -> %j', (input, expected) => {
+      expect(parseSublimeTextMax(input)).toBe(expected)
     })
   })
 

--- a/search/index.json.njk
+++ b/search/index.json.njk
@@ -17,6 +17,9 @@ permalink: "/search/index.json"
     {%- if pkg.outdated -%}
       "outdated": true,
     {%- endif -%}
+    {%- if pkg.st3_only -%}
+      "st3_only": true,
+    {%- endif -%}
     {%- if pkg.doa -%}
       "doa": true,
     {%- elif pkg.removed -%}
@@ -25,7 +28,7 @@ permalink: "/search/index.json"
       "archived_at": "{{ pkg.archived_at | timestamp }}",
     {%- endif %}
     "platforms": "{{ pkg.platforms | default([]) | join(",") }}",
-    "labels": "{{ pkg.labels | default([]) | join(",") }}",
+    "labels": "{{ pkg.labels | default([]) | join(",") | safe }}",
     "permalink": "/packages/{{ pkg.name | urlencode }}"
   }{{ "," if not loop.last }}
 {%- endfor %}

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -13,6 +13,11 @@ export class Card {
   }
 
   render() {
+    const cardRoot = this.clone.querySelector('.card')
+    if (cardRoot) {
+      cardRoot.classList.toggle('dimmed', Boolean(this.pkg.outdated))
+    }
+
     this.clone.querySelector('a').innerHTML = this.pkg.name
     this.clone.querySelector('a').setAttribute('href', this.pkg.permalink)
     this.authors(this.clone.querySelector('p.authors'))
@@ -134,6 +139,14 @@ export class Card {
     else {
       a.classList.add('button', 'label')
       a.setAttribute('href', searchQueryFor('label', name))
+      if (name == '<ST3') {
+        a.classList.add('outdated')
+        a.setAttribute('title', 'Outdated package for ST2')
+      }
+      if (name == 'ST3') {
+        a.classList.add('st3_only')
+        a.setAttribute('title', 'Compatible with ST3 only')
+      }
     }
 
     a.innerText = name

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -57,6 +57,7 @@ function createMinisearchInstance(MiniSearch) {
       'permalink',
       'magic_score',
       'outdated',
+      'st3_only',
     ],
     searchOptions: {
       boost: { author: 2 },

--- a/static/style/colors.css
+++ b/static/style/colors.css
@@ -22,6 +22,8 @@
 
   --red-1: hsl(7 98% 56%);
   --red-2: hsl(7 92% 54%);
+  --outdated-badge-bg: hsl(0 100% 66%);
+  --st3-badge-bg: hsl(25 100% 66%);
   --orange-1: hsl(32 94% 55%);
   --orange-2: hsl(32 92% 49%);
   --orange-3: hsl(32 90% 44%);
@@ -50,6 +52,8 @@
 
   --red-1: hsl(7 92% 54%);
   --red-2: hsl(7 98% 56%);
+  --outdated-badge-bg: hsl(0 100% 66%);
+  --st3-badge-bg: hsl(15 78% 49%);
   --orange-1: hsl(32 92% 49%);
   --orange-2: hsl(32 94% 55%);
   --orange-3: hsl(32 97% 67%);

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -126,6 +126,7 @@ section[name="labels"] .grid {
 
   .list & .labels {
     justify-content: flex-start;
+    margin-top: 18px;  /* usually collapses with margin-bottom from .description */
   }
 
   .list & .stats {
@@ -149,6 +150,21 @@ section[name="labels"] .grid {
     background: var(--background-2);
     &:hover:not(:disabled) {
       background: var(--background-3);
+    }
+  }
+  .button {
+    &.outdated,
+    &.st3_only {
+      color: var(--white);
+      font-size: 10px;
+    }
+
+    &.outdated {
+      background: var(--outdated-badge-bg);
+    }
+
+    &.st3_only {
+      background: var(--st3-badge-bg);
     }
   }
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -298,3 +298,6 @@ section {
 .section-heading-link {
   color: inherit;
 }
+.card.dimmed {
+  opacity: 0.8;
+}


### PR DESCRIPTION
We create two synthetic labels "st3" and "<st3", style them a bit different and get a lot for free.  

<img width="912" height="250" alt="image" src="https://github.com/user-attachments/assets/9b98743d-4d1e-4b98-b1b9-f712645fecef" />