### PR TITLE
fix #239 summary doesn't need to stretch so far

### DIFF
--- a/static/style/package.css
+++ b/static/style/package.css
@@ -98,6 +98,9 @@ ul.stats {
     outline-color: var(--orange-1);
     width: fit-content;
   }
+  &:open summary {
+    width: revert;
+  }
 
   ul {
     list-style: none;


### PR DESCRIPTION
Fixes #239

Before

<img width="1277" height="342" alt="Scherm­afbeelding 2025-11-23 om 20 09 57" src="https://github.com/user-attachments/assets/d0ad3774-2b70-41ef-a50d-58c49350a066" />

[After](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/fit-content) 

<img width="705" height="254" alt="Scherm­afbeelding 2025-11-23 om 20 10 04" src="https://github.com/user-attachments/assets/1efebe32-d795-4577-916c-f95eeb957959" />

<img width="687" height="136" alt="Scherm­afbeelding 2025-11-23 om 20 11 55" src="https://github.com/user-attachments/assets/d87d1366-929b-4f58-92d1-08b579798ec6" />

Second commit is for if you want the full area clickable when expanded:

<img width="1281" height="154" alt="Scherm­afbeelding 2025-11-23 om 20 16 45" src="https://github.com/user-attachments/assets/0a7c9bd6-3a88-4124-87e4-c5d160eaaed9" />
