### PR TITLE
Implement a way to re-enter auto mode on the labels page

### DIFF
--- a/static/labels.js
+++ b/static/labels.js
@@ -13,7 +13,7 @@ const searchInput = document.getElementById('search-field')
 const usageToggle = document.querySelector('[data-omit-single]')
 const urlParams = new URLSearchParams(window.location.search)
 const initialQuery = urlParams.get('q') ?? ''
-let manualOmitChoice = false
+let autoMode = true
 let omitSingles = initialQuery.trim() === ''
 
 const cardFilter = (card) => {
@@ -65,7 +65,7 @@ const updateUsageToggleUI = () => {
 }
 
 const updateOmitState = (value, { manual = false, triggerSearch = false } = {}) => {
-  if (!manual && manualOmitChoice) {
+  if (!manual && !autoMode) {
     return false
   }
 
@@ -80,9 +80,9 @@ const updateOmitState = (value, { manual = false, triggerSearch = false } = {}) 
     // If the user is turning omit-singles back on while the
     // query is empty (pristine state), return to auto mode.
     if (normalized && currentQuery === '') {
-      manualOmitChoice = false
+      autoMode = true
     } else {
-      manualOmitChoice = true
+      autoMode = false
     }
   }
   updateUsageToggleUI()


### PR DESCRIPTION
Mitigates #242 

By re-entering auto-mode, new users that just clicked around will less likely see a less useful state. 