### PR TITLE
Fix: ensure onsubmit runs

### DIFF
--- a/static/keys.js
+++ b/static/keys.js
@@ -166,12 +166,15 @@ document.addEventListener('keydown', (event) => {
     return
   }
 
-  const card = Array.from(document.querySelectorAll(CARD_SELECTOR)).find(isVisibleCard)
-  if (!card) {
-    return
-  }
+  // Schedule our side-effect so the onsubmit has a chance to run
+  setTimeout(() => {
+    const card = Array.from(document.querySelectorAll(CARD_SELECTOR)).find(isVisibleCard)
+    if (!card) {
+      return
+    }
 
-  focusCardHeading(card)
+    focusCardHeading(card)
+  })
 })
 
 //


### PR DESCRIPTION
We catch "enter" in keys.js and move -- as a direct, immediate action -- the focus *away* from the form *to* a card.  As a result, the event bubbling up will never submit any form as none has the input focus (anymore).

Since we know that our search results are rendered synchronous, we can just schedule our focus move / side-effect for the next task.

Ref #252 