### PR TITLE
Always use our ranking in "relevance" mode

### DIFF
--- a/static/module/list.js
+++ b/static/module/list.js
@@ -270,11 +270,7 @@ export class List {
       ? this.search.search(query)
       : this.search.all()
 
-    // when not searching for strings, sorting magically switches to install number
     let effectiveSort = sortBy
-    if (effectiveSort === 'relevance' && !this.search.stringSearch) {
-      effectiveSort = 'installed'
-    }
     if (usingWildcard && effectiveSort.startsWith('author')) {
       effectiveSort = 'list-' + effectiveSort
     }


### PR DESCRIPTION
Iterates on https://github.com/packagecontrol/thecrawl/issues/63 (f38435e3a (fix #63 sort by installs if no search string)).

Background:  we switched to "installed" because for specialized searches (e.g. "label:") we had no meaningful Minisearch ranking score. In order to have any stable ranking we just switched to "installed". That has changed since as we now have a full proper ranking algorithm.