### PR TITLE
Fix link to "static/label-icons.svg" in production

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -14,6 +14,9 @@
   {% inline_js 'static/_handle_theme.js' %}
   {% inline_js 'static/_handle_search_url.js' %}
   {% inline_js 'static/_human_date.js' %}
+  <script>
+    window.STATIC_BASE = '/{{ "static/" | bust }}';
+  </script>
 
   <link rel="stylesheet" href="{{ '/static/styles.css' | bust}}">
   <link rel="icon" href="/assets/favicon.ico">

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -81,7 +81,7 @@
             {% if icon_id %}
               {% set tint = (label | label_icon_tint) if with_icons else '' %}
               <svg class="label-icon{{ (' label-icon--' ~ tint) if tint }}" aria-hidden="true">
-                <use href="/static/label-icons.svg#{{ icon_id }}"></use>
+                <use href="/{{ 'static/label-icons.svg' | bust }}#{{ icon_id }}"></use>
               </svg>
             {% endif %}
             {{ label }}

--- a/labels.njk
+++ b/labels.njk
@@ -41,7 +41,7 @@ date: Last Modified
           {% if icon_id %}
             {% set tint = item.key | label_icon_tint %}
             <svg class="label-icon{{ (' label-icon--' ~ tint) if tint }}" aria-hidden="true">
-              <use href="/static/label-icons.svg#{{ icon_id }}"></use>
+              <use href="/{{ 'static/label-icons.svg' | bust }}#{{ icon_id }}"></use>
             </svg>
           {% endif %}
           {{ item.key }}

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -2,6 +2,7 @@ export class Card {
   pkg = {}
   clone
   compact = false
+  staticBase = window.STATIC_BASE ?? '/static/'
 
   constructor(data, compact = null) {
     this.pkg = data
@@ -145,7 +146,7 @@ export class Card {
         svg.setAttribute('class', `label-icon${tint ? ' label-icon--' + tint : ''}`)
         svg.setAttribute('aria-hidden', 'true')
         const use = document.createElementNS(svgNS, 'use')
-        use.setAttribute('href', `/static/label-icons.svg#${iconId}`)
+        use.setAttribute('href', `${this.staticBase}label-icons.svg#${iconId}`)
         svg.appendChild(use)
         a.appendChild(svg)
       }


### PR DESCRIPTION
There is no /static/ dir in production as we hashify the path.

For the passthrough to the live JS protions, we need to inject it in the head with a small inline script.  That's generally how life is.