### PR TITLE
LIMIT_DATASET=<number> should choose newest and popular packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ You can also pass a comma-separated list of package names to focus on specific e
 LIMIT_DATASET="A File Icon,GitGutter" npm run dev -- --quiet
 ```
 
+If you quickly want to see old packages:
+
+```bash
+LIMIT_DATASET=-100 npm run dev -- --quiet
+```
+
 Or run it on `http-server`, e.g.
 
 ```bash

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -316,20 +316,25 @@ export default function (eleventyConfig) {
   const limitRaw = process.env.LIMIT_DATASET
   if (typeof limitRaw === 'string' && limitRaw.trim() !== '') {
     const numeric = parseInt(limitRaw, 10)
-    if (Number.isFinite(numeric) && numeric > 0) {
+    if (Number.isFinite(numeric) && numeric !== 0) {
       const before = all_packages.length
-      const newestCount = Math.ceil(numeric / 2)
-      const byNewest = [...all_packages].sort((a, b) => {
-        const tsA = toTimestamp(a.first_seen) ?? 0
-        const tsB = toTimestamp(b.first_seen) ?? 0
-        return tsB - tsA
-      }).slice(0, newestCount)
+      const limit = Math.abs(numeric)
       const installsFor = (pkg) => {
         const yearly = stats[pkg.name]?.installs?.yearly
         if (!Array.isArray(yearly)) return 0
         return yearly.reduce((sum, value) => sum + (Number(value) || 0), 0)
       }
-      const byPopular = [...all_packages].sort((a, b) => installsFor(b) - installsFor(a))
+      const timestampFor = pkg => toTimestamp(pkg.first_seen) ?? 0
+      const byNewest = [...all_packages].sort((a, b) => {
+        const tsA = timestampFor(a)
+        const tsB = timestampFor(b)
+        return numeric > 0 ? tsB - tsA : tsA - tsB
+      }).slice(0, Math.ceil(limit / 2))
+      const byPopular = [...all_packages].sort((a, b) => {
+        const instA = installsFor(a)
+        const instB = installsFor(b)
+        return numeric > 0 ? instB - instA : instA - instB
+      })
 
       const limited = []
       const seen = new Set()
@@ -341,14 +346,15 @@ export default function (eleventyConfig) {
         limited.push(pkg)
       }
       byNewest.forEach(pushUnique)
-      if (limited.length < numeric) {
+      if (limited.length < limit) {
         for (const pkg of byPopular) {
           pushUnique(pkg)
-          if (limited.length >= numeric) break
+          if (limited.length >= limit) break
         }
       }
       all_packages = limited
-      console.warn(`[eleventy] LIMIT_DATASET=${numeric} active: ${before} -> ${all_packages.length} packages`)
+      const modeLabel = numeric > 0 ? '' : '(oldest/unpopular mix)'
+      console.warn(`[eleventy] LIMIT_DATASET=${numeric} active ${modeLabel}: ${before} -> ${all_packages.length} packages`)
     } else {
       const names = limitRaw
         .split(',')


### PR DESCRIPTION
We just took the first n packages from the workspace, just take the newest/most popular ones.  Or, if you specify `-n` the oldest.  The latter is probably rarely used; but needed if you design the abandoned packages UI.   