### PR TITLE
Ignore date annotations in the "Currently failing" section

### DIFF
--- a/static/status.js
+++ b/static/status.js
@@ -636,6 +636,8 @@ function extractCurrentlyFailing(notes) {
   return slice
     .split('\n')
     .map(line => line.trim())
+    // Ignore trailing relative-date annotations like "[since 3 months]".
+    .map(line => line.replace(/\s*\[[^\]]+\]\s*$/, ''))
     .filter(Boolean)
     .join('\n')
 }


### PR DESCRIPTION
Since we use relative dates, they change their representation although nothing actually changed.  Strip them.