### PR TITLE
Update download links to the new repackager endpoint

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -187,7 +187,7 @@ function basePackage(pkg, stat) {
     // Provide repackager links if possible
     if (supportedRepackagerHosts.some(n => url.startsWith(n))) {
       const encodedName = encodeURIComponent(pkg.name)
-      release.download_url = `${repackagerSite}/?url=${url}&name=${encodedName}`
+      release.download_url = `${repackagerSite}/packages/${encodedName}?url=${url}`
     }
   }
 


### PR DESCRIPTION
The new endpoint on the repackager matches our package URL.

E.g. for a package at

   /packages/Nilesoft%20Shell%20Script
   /packages/Nilesoft%20Shell%20Script?url=https://codeload...