### PR TITLE
Do not set "no-cache" for the "logs.json" URL's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	# installation stats
 	curl -o stats.json -L "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/stats.json"
 	# thecrawl logs
-	curl -o logs.json -L "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/logs.json"
+	curl -o static/logs.json -L "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/logs.json"
 	# compile eleventy (production)
 	ELEVENTY_ENV=production NODE_ENV=production npx @11ty/eleventy
 	# add compiled channels for public consumption

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -506,7 +506,6 @@ export default function (eleventyConfig) {
     disableLiveLink: Boolean(process.env.DISABLE_L_LINK),
   })
 
-  eleventyConfig.addPassthroughCopy('logs.json')
   // Default permalink: output files with their extension (e.g., /page.html)
   // Can be overridden per-template (e.g., RSS feed or JSON endpoints)
   eleventyConfig.addGlobalData('permalink', () => {

--- a/static/status.js
+++ b/static/status.js
@@ -133,12 +133,13 @@ function resolveIndexFromUrl() {
 }
 
 const ASSET_URL = 'https://repackager.sublimetext.io/logs.json'
+const FALLBACK_URL = `${window.STATIC_BASE ?? '/static/'}logs.json`
 const LOG_REFRESH_MS = 10 * 60 * 1000
 
 async function loadLogs() {
   const sources = [
     () => fetch(ASSET_URL),
-    () => fetch('/logs.json', { cache: 'no-cache' }),
+    () => fetch(FALLBACK_URL),
   ]
 
   let lastError = null


### PR DESCRIPTION
Also:  load in new logs every ten minutes.