### PR TITLE
Fixup pager vertical position

### DIFF
--- a/static/style/pagination.css
+++ b/static/style/pagination.css
@@ -45,8 +45,7 @@
   align-self: end;
   gap: 1rem;
   position: relative;
-  top: -16px;
-  line-height: var(--grid-line);
+  top: -15px;
 
   .button-group {
     display: flex;
@@ -67,7 +66,7 @@
     .pager-nav-symbol {
       display: inline-block;
       position: relative;
-      top: -0.07em;
+      top: -2px;
     }
   }
 


### PR DESCRIPTION
The position variation comes from a rounding error introduced deep down in .pager-nav-symbol:top 0.07em (which is 1.68 iirc px).  
The line-height fix is not doing anything as we don't have a different font-size here.  If we fix the 0.07em to 2px (or any other stable px value) we have a stable position, or a stable, easy way to align the icons vertically (which is difficult as we know because of their thin and loose bottom end).  top: -15 instead of top -16 decreases the gap to the card so that the h2 on the left side and the pagination on the right side have the same gap, which is or is not desirable.  However the light and smaller right size tends to fly quicker (looses the connection) than the bold and heavy h2.  (That's why, in the old WS/layout, the right side was usually 1px nearer to the card than the left side. Slightly falling.)  

After
<img width="1353" height="105" alt="image" src="https://github.com/user-attachments/assets/4d149e8d-6752-48df-a7ce-a88fe0bfc7cf" />
