### PR TITLE
Extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# python
+__pycache__/
+*.py[co]
+
+# sublime text
+.sublime/
+*.sublime-project
+*.sublime-workspace
+
+# data files
 .pypi-cache/
 channel*.json
 libraries-metadb.json


### PR DESCRIPTION
Ignore common python cache files and likely unwanted ST related resources.