### PR TITLE
feat: add top navigation bar for better discoverability

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -4,6 +4,7 @@
 
   <body>
     {% include "header.njk" %}
+    {% include "site-nav.njk" %}
     {% include "templates.njk" %}
 
     <main>

--- a/_includes/site-nav.njk
+++ b/_includes/site-nav.njk
@@ -1,0 +1,15 @@
+{% import "util/macros.njk" as util %}
+
+<nav class="site-nav" aria-label="Site navigation">
+  <div class="site-nav-links">
+    <a href="/about">About</a>
+    <a href="https://docs.sublimetext.io/guide/package-control/usage.html">Using Package Control</a>
+    <a href="https://docs.sublimetext.io/guide/package-control/submitting.html">Submit your package</a>
+  </div>
+  <div class="site-nav-meta">
+    <a href="/status">Status</a>
+    <a class="site-nav-github" href="https://github.com/packagecontrol/thecrawl/tree/gh-pages" aria-label="View source on GitHub">
+      {{ util.icon('octocat') }}
+    </a>
+  </div>
+</nav>

--- a/static/style/site-nav.css
+++ b/static/style/site-nav.css
@@ -1,0 +1,62 @@
+/* Thin secondary navigation bar below the header */
+.site-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: var(--max-content);
+  margin: -13px auto 16px auto;
+  padding: 3px var(--side-padding);
+  font-size: 16px;
+  color: var(--foreground-3);
+  border-top: 1px solid var(--background-4);
+
+  a {
+    color: inherit;
+    transition: color 0.1s ease-in-out;
+
+    &:hover {
+      color: var(--foreground-1);
+    }
+  }
+}
+
+/* On homepage (header has h1), pull nav closer to tagline */
+header:has(h1) + .site-nav {
+  margin: -48px auto 51px auto;
+}
+
+.site-nav-links {
+  display: flex;
+  gap: 1.5em;
+}
+
+.site-nav-meta {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
+.site-nav-github {
+  display: flex;
+  align-items: center;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+/* On very narrow screens, hide less essential links */
+@media (max-width: 400px) {
+  .site-nav {
+    font-size: 14px;
+  }
+
+  .site-nav-links {
+    gap: 1em;
+  }
+
+  .site-nav-meta {
+    gap: 0.75em;
+  }
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,6 +1,7 @@
 @import url('style/typography.css');
 @import url('style/colors.css');
 @import url('style/buttons.css');
+@import url('style/site-nav.css');
 @import url('style/header.css');
 @import url('style/footer.css');
 @import url('style/grid.css');


### PR DESCRIPTION
Fix #335

Just for illustration purposes. Some people may prefer such navbar information on the side. Branch for illustration is https://ilyazar.github.io/thecrawl/

For the moment at the top as a short minimal fix , so people see whats going on

# Light:
<img width="1306" height="633" alt="image" src="https://github.com/user-attachments/assets/f9bbc2c9-95a9-456f-aa85-17eeba340d02" />

# Dark
<img width="1342" height="815" alt="image" src="https://github.com/user-attachments/assets/5644ffb1-556a-49e9-a0a6-4abc102802c5" />



cheers