### PR TITLE
fix #82 make hand-picked labels stand out

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -260,13 +260,18 @@ function basePackage(pkg, stat) {
     return minB - minA // Higher min build first
   })
 
-  const labels = pkg.labels?.slice() ?? []
-  if (!supportsModernSublime) labels.push('ST2')
-  if (supportsModernSublime && doesNotSupportNewestSublime) labels.push('ST3')
+  let labels = pkg.labels?.slice() ?? []
+  labels = labels.sort((a) => {
+    if (['language syntax', 'snippets', 'linting', 'auto-complete', 'color scheme', 'theme'].includes(a)) {
+      return -1
+    }
+  })
+  if (!supportsModernSublime) labels.unshift('ST2')
+  if (supportsModernSublime && doesNotSupportNewestSublime) labels.unshift('ST3')
   if (pkg.removed) {
-    labels.push('RIP')
+    labels.unshift('RIP')
   } else if (pkg.archived_at) {
-    labels.push('MIA')
+    labels.unshift('MIA')
   }
 
   const platforms = util.computePlatformLabelsForSearch(rawReleases).sort()

--- a/static/style/buttons.css
+++ b/static/style/buttons.css
@@ -87,7 +87,20 @@
   &.label-more:hover {
     color: var(--orange-2);
   }
+
+  &.label {
+    &[href*='language%20syntax'],
+    &[href*='snippets'],
+    &[href*='linting'],
+    &[href*='auto-complete'],
+    &[href*='color%20scheme'],
+    &[href*='theme'] {
+      color: var(--foreground-1);
+      font-weight: bold;
+    }
+  }
 }
+
 
 span.button {
   cursor: revert;

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -108,7 +108,7 @@ section[name="labels"] .grid {
     top: 18px;
     right: 1rem;
     gap: 0;
-    font-size: 13px;
+    font-size: 11px;
     background: inherit;
     color: var(--foreground-3);
     svg {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -108,7 +108,7 @@ section[name="labels"] .grid {
     top: 18px;
     right: 1rem;
     gap: 0;
-    font-size: 12px;
+    font-size: 13px;
     background: inherit;
     color: var(--foreground-3);
     svg {
@@ -118,7 +118,7 @@ section[name="labels"] .grid {
   }
 
   .labels {
-    font-size: 12px;
+    font-size: 13px;
     justify-content: flex-end;
     padding: 0;
     margin: 0;

--- a/static/style/search.css
+++ b/static/style/search.css
@@ -68,6 +68,11 @@ form[name='search'] {
     .button-group.labels {
       flex: 1 1 auto;
       min-width: 0;
+
+      .button.label {
+        font-weight: normal;
+        color: var(--foreground-2);
+      }
     }
 
     .search-shortcuts-links {


### PR DESCRIPTION
The discussion in #82 ended up going towards "just" using bold (and a slight color contrast adjustment) to highlight the hand-picked labels. We've gone a few steps way from colorful lately and I think that's a good thing after all. Also, the language icons/logos already add color. Bold does what it needs to do while also being completely inoffensive. 

I considered adding LSP to that list, but it feels a bit random because that's not part of the selected labels we put under the search field. Besides, all LSP packages already have LSP- in their name, so LSP is written all over them to the point that highlighting the label feels unnecessary. 
I also considered adding AI to that list, but IMO it's not that kind of label right now. We're in the middle of the hype cycle, perhaps we'll end up with more of a SublimeLinter/LSP kind of situation around interacting with LLMS and agents. Right now it can mean anything.

So, tiny little PR:

<img width="560" height="459" alt="Scherm­afbeelding 2026-04-08 om 10 55 54" src="https://github.com/user-attachments/assets/51e8c714-2137-4583-96b1-447b6a874257" />

<img width="851" height="706" alt="Scherm­afbeelding 2026-04-08 om 10 58 12" src="https://github.com/user-attachments/assets/bc44b801-915c-4c85-b732-ac8039f5c319" />

<img width="562" height="298" alt="Scherm­afbeelding 2026-04-08 om 11 06 32" src="https://github.com/user-attachments/assets/35770804-1b3f-46dd-a6bb-c08265905360" />
