### PR TITLE
Iterate RIP pages

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -141,12 +141,14 @@
       </a>
     </h3>
 
-    <p class="authors">by
-    {% for author in pkg.author -%}
-      {% set q = searchQueryFor('author', author) %}
-      <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
-    {%- endfor %}
-    </p>
+    {% if pkg.author and (pkg.author | length) > 0 %}
+      <p class="authors">by
+      {% for author in pkg.author -%}
+        {% set q = searchQueryFor('author', author) %}
+        <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
+      {%- endfor %}
+      </p>
+    {% endif %}
 
     {% if pkg.description %}
       <p class="description">

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -85,15 +85,16 @@ isPackagePage: true
     {% endif %}
   </p>
 
-  {# Hide completely empty charts: no install stats and no release in the running year window #}
-  {% set stats_sum = (pkg.weekly_installs | sum) + (pkg.weekly_removals | sum) + (pkg.weekly_upgrades | sum) %}
+  {# Hide completely empty charts: no visible install/upgrade stats and no release in the running year window #}
+  {# Removals alone are not drawn when installs are zero, so they should not trigger the chart. #}
+  {% set stats_sum = (pkg.weekly_installs | sum) + (pkg.weekly_upgrades | sum) %}
   {% set has_install_stats = stats_sum > 0 %}
   {% set has_release_in_window = false %}
   {% if (pkg.allReleases | length) > 0 and pkg.weekly_dates and (pkg.weekly_dates | length) > 0 %}
     {% set latest_release = pkg.allReleases | first %}
     {% if latest_release.date %}
       {% set release_index = pkg.weekly_dates | iso_week_index(latest_release.date) %}
-      {% if release_index is not none and release_index < (pkg.weekly_dates | length) %}
+      {% if release_index is not none and release_index < (pkg.weekly_installs | length) %}
         {% set has_release_in_window = true %}
       {% endif %}
     {% endif %}

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -106,7 +106,7 @@ isPackagePage: true
     </div>
   {% endif %}
 
-  {% if pkg.installed > 0 or pkg.stars > 0 %}
+  {% if not pkg.removed and (pkg.installed > 0 or pkg.stars > 0) %}
     <ul class="stats">
       {{ pack.installs(pkg.installed) }}
       {{ pack.stars(pkg.stars) }}

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -61,8 +61,9 @@ isPackagePage: true
     {% endif %}
 
     {% if pkg.removed %}
-      {% if pkg.created_at -%}
-        Created <human-date clickable datetime="{{ pkg.created_at }}">{{ pkg.created_at | date_format }}</human-date>,
+      {% set removed_first_seen = pkg.first_seen or pkg.created_at %}
+      {% if removed_first_seen -%}
+        First seen <human-date clickable datetime="{{ removed_first_seen }}">{{ removed_first_seen | date_format }}</human-date>,
         removed <human-date clickable datetime="{{ pkg.removed }}">{{ pkg.removed | date_format }}</human-date>.
       {% else %}
         Removed <human-date clickable datetime="{{ pkg.removed }}">{{ pkg.removed | date_format }}</human-date>.

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -101,7 +101,7 @@ isPackagePage: true
   {% endif %}
 
   {% if has_install_stats or has_release_in_window %}
-    <div class="chart-container">
+    <div class="chart-container{{ ' chart-container-rip' if pkg.removed }}">
       {{ charts.chart(pkg.installed, pkg.weekly_installs, pkg.weekly_removals, pkg.weekly_upgrades, pkg.weekly_dates, pkg.allReleases) }}
     </div>
   {% endif %}

--- a/static/index.js
+++ b/static/index.js
@@ -176,6 +176,10 @@ document.addEventListener('click', (event) => {
   }
 
   const targetUrl = new URL(target.href, window.location.origin)
+  if (targetUrl.origin !== window.location.origin) {
+    return
+  }
+
   // read possible query and sort from the clicked link
   let newQuery = targetUrl.searchParams.get('q')
   let newSort = targetUrl.searchParams.get('sort')

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -25,7 +25,7 @@ export class Card {
     this.authors(this.clone.querySelector('p.authors'))
 
     const descr_el = this.clone.querySelector('p.description')
-    if (this.compact) {
+    if (this.compact || !this.pkg.description) {
       descr_el.remove()
     } else {
       descr_el.innerHTML = this.pkg.description
@@ -152,22 +152,24 @@ export class Card {
   }
 
   authors(parent) {
-    if (this.pkg.author.length < 1) {
+    if (!this.pkg.author) {
       parent.remove()
       return
     }
 
+    const list = this.pkg.author.split(',').map(name => name.trim())
+
     parent.innerHTML = 'by '
-    const list = this.pkg.author.split(',')
-    list.forEach((name, iter) => {
+    for (let i = 0; i < list.length; i += 1) {
+      const name = list[i]
       const a = document.createElement('a')
       a.setAttribute('href', searchQueryFor('author', name))
       a.innerText = name
       parent.appendChild(a)
-      if (iter + 1 < list.length) {
+      if (i + 1 < list.length) {
         parent.appendChild(document.createTextNode(', '))
       }
-    })
+    }
   }
 
   platforms() {

--- a/static/style/chart.css
+++ b/static/style/chart.css
@@ -86,7 +86,7 @@ section:has(.chart-container)::after {
 
   /* spacer between the bars */
   .week-slice-bg {
-    fill: var(--background-2);
+    fill: transparent;
     transition: fill .1s;
   }
   /* bars behind the weeks */

--- a/static/style/chart.css
+++ b/static/style/chart.css
@@ -22,6 +22,16 @@
     width: 100%;
     float: right;
   }
+
+  &.chart-container-rip {
+    filter: grayscale(1);
+    @media (min-width: 1200px) {
+      margin: 2em 0 0;
+      padding: 24px 0 22px;
+      border-left: 0;
+      float: none;
+    }
+  }
 }
 
 /* Dark theme overrides (values from the darker chart changes) */


### PR DESCRIPTION
After scraping pc.io for all the old tombstoned packages and after introducing the registry service, the RIP pages relied on data that wasn't usually present. Adjust to that. 

Most importantly switch from "created_at" to "first_seen".  

Also has two completely unrelated CSS tweaks. 