### PR TITLE
Add synthetic label for failing packages

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -80,6 +80,10 @@
           <a class="button label state state-warning" href="/?q={{ q }}" title="Repository was archived on {{ pkg.archived_at | date_format }}">
             {{ label }}
           </a>
+        {% elif label == 'FAILING' %}
+          <a class="button label state state-failing" href="/?q={{ q }}" title="Package metadata updates are currently failing">
+            {{ label }}
+          </a>
         {% elif label == 'RIP' %}
           <a class="button label state state-bad" href="/?q={{ q }}" title="Package was removed on {{ pkg.removed | date_format }}">
             {{ label }}

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -266,6 +266,9 @@ function basePackage(pkg, stat) {
       return -1
     }
   })
+  if (pkg.failing_since || pkg.fail_reason) {
+    labels.unshift('FAILING')
+  }
   if (!supportsModernSublime) labels.unshift('ST2')
   if (supportsModernSublime && doesNotSupportNewestSublime) labels.unshift('ST3')
   if (pkg.removed) {

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -269,8 +269,11 @@ function basePackage(pkg, stat) {
   if (pkg.failing_since || pkg.fail_reason) {
     labels.unshift('FAILING')
   }
-  if (!supportsModernSublime) labels.unshift('ST2')
-  if (supportsModernSublime && doesNotSupportNewestSublime) labels.unshift('ST3')
+  if (!supportsModernSublime) {
+    labels.unshift('ST2')
+  } else if (doesNotSupportNewestSublime) {
+    labels.unshift('ST3')
+  }
   if (pkg.removed) {
     labels.unshift('RIP')
   } else if (pkg.archived_at) {

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -230,6 +230,10 @@ export class Card {
           parent.appendChild(this.button(item,
             'Repository was archived on ' + this.pretty(new Date(Number(this.pkg.archived_at) * 1000))))
           break
+        case 'FAILING':
+          parent.appendChild(this.button(item,
+            'Package metadata updates are currently failing'))
+          break
         case 'RIP':
           parent.appendChild(this.button(item,
             'Package was removed on ' + this.pretty(new Date(Number(this.pkg.removed) * 1000))))
@@ -266,6 +270,9 @@ export class Card {
     }
     if (['ST3', 'MIA'].includes(name)) {
       a.classList.add('state', 'state-warning')
+    }
+    if (['FAILING'].includes(name)) {
+      a.classList.add('state', 'state-failing')
     }
 
     if (tooltip) {

--- a/static/module/search.js
+++ b/static/module/search.js
@@ -48,6 +48,7 @@ export function processQueryString(rawValue = '', filterFlags = {}) {
   let hasFreeText = false
 
   let value = typeof rawValue === 'string' ? rawValue : String(rawValue ?? '')
+  value = rewriteSyntheticLabelAliases(value)
 
   const extractFilter = (field, regex, buildQuery = () => {}) => {
     const matches = []
@@ -134,6 +135,23 @@ export function processQueryString(rawValue = '', filterFlags = {}) {
   })
 
   return { queries, hasFreeText, filter }
+}
+
+const SYNTHETIC_LABEL_ALIASES = {
+  fail: 'FAILING',
+  failing: 'FAILING',
+  mia: 'MIA',
+  rip: 'RIP',
+}
+
+function rewriteSyntheticLabelAliases(value) {
+  return value.replace(/(^|\s):([a-z][\w-]*)\b/gi, (match, prefix, rawAlias) => {
+    const canonicalLabel = SYNTHETIC_LABEL_ALIASES[rawAlias.toLowerCase()]
+    if (!canonicalLabel) {
+      return match
+    }
+    return `${prefix}label:"${canonicalLabel}"`
+  })
 }
 
 function normalizeResults(entries = []) {

--- a/static/module/search.test.js
+++ b/static/module/search.test.js
@@ -77,6 +77,37 @@ describe('processQueryString', () => {
     ])
   })
 
+  it('maps synthetic label aliases to label filters', () => {
+    expect(processQueryString(':rip :fail :failing :mia').queries).toEqual([
+      {
+        queries: ['RIP'],
+        fields: ['labels'],
+      },
+      {
+        queries: ['FAILING'],
+        fields: ['labels'],
+      },
+      {
+        queries: ['FAILING'],
+        fields: ['labels'],
+      },
+      {
+        queries: ['MIA'],
+        fields: ['labels'],
+      },
+    ])
+    expect(processQueryString(':mia').hasFreeText).toBe(false)
+  })
+
+  it('keeps unknown aliases as free text', () => {
+    expect(processQueryString(':mystery').queries).toEqual([
+      {
+        queries: [':mystery'],
+        fields: ['name', 'description', 'author', 'labels'],
+      },
+    ])
+  })
+
   it('treats disabled filters as free text', () => {
     const result = processQueryString(
       'author:someone label:ux platform:web',

--- a/static/style/colors.css
+++ b/static/style/colors.css
@@ -32,6 +32,9 @@
   --green-2: hsl(80 67% 47%);
   --green-3: hsl(80 65% 42%);
 
+  --state-failing-border-color: hsl(237.15deg 92% 54%);
+  --state-failing-text-color: hsl(208.16deg 90.39% 52.64%);
+
   --purple-1: hsl(275 76% 58%);
   --pink-1: hsl(345 76% 58%);
   --graphite-1: hsl(245 21% 42%);
@@ -63,6 +66,9 @@
   --green-1: hsl(80 67% 47%);
   --green-2: hsl(80 70% 49%);
   --green-3: hsl(80 72% 58%);
+
+  --state-failing-border-color: hsl(237.15deg 92% 54%);
+  --state-failing-text-color: hsl(208.16deg 90.39% 52.64%);
 
   --purple-1: hsl(275 80% 64%);
   --pink-1: hsl(345 82% 62%);

--- a/static/style/colors.css
+++ b/static/style/colors.css
@@ -38,6 +38,9 @@
   --purple-1: hsl(275 76% 58%);
   --pink-1: hsl(345 76% 58%);
   --graphite-1: hsl(245 21% 42%);
+
+  --warning-message-background: hsl(0deg 0% 91.94%);
+  --warning-message-border: hsl(0deg 0.23% 75.25%);
 }
 
 :root[data-theme='dark'] {
@@ -73,4 +76,7 @@
   --purple-1: hsl(275 80% 64%);
   --pink-1: hsl(345 82% 62%);
   --graphite-1: hsl(245 21% 60%);
+
+  --warning-message-background: hsl(214deg 20.59% 24.6%);
+  --warning-message-border: hsl(0deg 0% 24.54%);
 }

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -233,18 +233,26 @@ ul.stats {
 .warning-message {
   padding: 1.6em;
   border-radius: 6px;
-  background: var(--background-1);
+  background: var(--warning-message-background);
+  border: 1px solid var(--warning-message-border);
   margin: 18px auto 8px auto;
   text-align: center;
   max-width: 32rem;
   overflow-wrap: anywhere;
   svg {
     color: var(--red-1);
-    width: 32px;
-    height: 32px;
+    width: 24px;
+    height: 24px;
   }
   h2 {
-    font-size: 21px;
-    line-height: 26px;
+    font-size: 16px;
+    line-height: 16px;
+    text-align: left;
+  }
+  p {
+    text-align: left;
+    font-family: monospace;
+    white-space: pre-wrap;
+    margin: 0;
   }
 }

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -152,6 +152,13 @@ ul.stats {
         background: rgb(from var(--red-1) r g b / 0.12);
       }
     }
+    &.state-failing {
+      border-color: var(--state-failing-border-color);
+      color: var(--state-failing-text-color);
+      &:hover {
+        background: rgb(from var(--state-failing-text-color) r g b / 0.12);
+      }
+    }
     &.platform-macos,
     &.platform-macos-x64 {
       background: var(--blue-1);


### PR DESCRIPTION
Derive a FAIL marker when failing_since or fail_reason is present and
prepend it with other synthetic labels.

Render FAIL as a another synthetic state badge in both Nunjucks and JS card paths and
provide a "concise" tooltip.

Maybe we can do a good tooltip later.

E.g.

<img width="864" height="381" alt="image" src="https://github.com/user-attachments/assets/d3c36cdf-92ba-418b-b752-8991134d7ba2" />

Added shortcut search queries: ":rip :fail :mia"

This merely for devs I guess.