### PR TITLE
Harmonize media-query breakpoints at 80rem

### DIFF
--- a/static/style/buttons.css
+++ b/static/style/buttons.css
@@ -44,17 +44,13 @@
 
   &.is-active {
     background: var(--background-4);
-    box-shadow: inset 2px 2px 3px rgb(0 0 0 / 0.15);
-    &:hover {
-      background: var(--background-3);
-    }
+    box-shadow: inset 2px 2px 0px rgb(0 0 0 / 0.15);
+    border: 1px solid #f8f8f8;
+    border-width: 0 2px 2px 0;
 
     :root[data-theme='dark'] & {
-      box-shadow: inset 2px 2px 3px rgb(0 0 0 / 0.25);
-      background: var(--background-3);
-      &:hover {
-        background: var(--background-4);
-      }
+      box-shadow: inset 2px 2px 0px rgb(0 0 0 / 25%);
+      border-color: #666666;
     }
   }
 

--- a/static/style/chart.css
+++ b/static/style/chart.css
@@ -15,7 +15,7 @@
   max-width: calc(var(--max-content) * 2/3 - var(--spacing));
   margin: 14px 0 42px 0;
 
-  @media (min-width: 1200px) {
+  @media (width >= 80rem) {
     margin: 0 0 0 var(--spacing);
     padding: 24px 0 22px var(--spacing);
     border-left: 1px solid var(--background-4);
@@ -25,7 +25,7 @@
 
   &.chart-container-rip {
     filter: grayscale(1);
-    @media (min-width: 1200px) {
+    @media (width >= 80rem) {
       margin: 2em 0 0;
       padding: 24px 0 22px;
       border-left: 0;

--- a/static/styles.css
+++ b/static/styles.css
@@ -18,7 +18,7 @@ html {
   --max-content: 78rem;
   --max-line: 52rem; /* limit paragraph line length for readability at 2/3 of 78 */
   --side-padding: 1rem;
-  @media (min-width: var(--max-content)) {
+  @media (width >= 80rem) {
     --side-padding: 1.75rem;
   }
 
@@ -256,8 +256,14 @@ section {
     }
   }
 
-  &[name="package"] [id="main-content"]:focus-visible {
-    outline: none;
+  &[name="package"] {
+    @media (width < 80rem) {
+      max-width: var(--max-line);
+      margin: auto;
+    }
+    & [id="main-content"]:focus-visible {
+      outline: none;
+    }
   }
 }
 


### PR DESCRIPTION
`(min-width: var(--max-content))` is actually not supported and ignored.
Fix that, but use `(--max-content + 2 * --side-padding) == 80rem`.

Harmonize `1200px -> 80rem` to the same value.

