### PR TITLE
Stabilize featured label ordering

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -12,6 +12,15 @@ const supportedRepackagerHosts = [
   'https://codelab.org/',
   'https://gitlab.com/',
 ]
+const FEATURED_LABELS = [
+  'language syntax',
+  'snippets',
+  'linting',
+  'auto-complete',
+  'color scheme',
+  'theme',
+]
+const LABELS_RANK = new Map(FEATURED_LABELS.map((label, index) => [label, index]))
 
 const MS_IN_DAY = 24 * 60 * 60 * 1000
 const MAGIC_FRESHNESS_WINDOW_DAYS = 365 * 2 // bonus for packages that had updates
@@ -260,12 +269,7 @@ function basePackage(pkg, stat) {
     return minB - minA // Higher min build first
   })
 
-  let labels = pkg.labels?.slice() ?? []
-  labels = labels.sort((a) => {
-    if (['language syntax', 'snippets', 'linting', 'auto-complete', 'color scheme', 'theme'].includes(a)) {
-      return -1
-    }
-  })
+  let labels = util.sortFeaturedLabelsFirst(pkg.labels, LABELS_RANK)
   if (pkg.failing_since || pkg.fail_reason) {
     labels.unshift('FAILING')
   }

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -49,6 +49,18 @@ export function computePlatformLabelsForSearch(releases) {
 }
 
 /**
+ * Move featured labels to the front while preserving stable order.
+ * - Featured labels are ordered by rank.
+ * - Non-featured labels keep their original relative order.
+ * @param {string[] | undefined | null} labels
+ * @param {Map<string, number> | undefined | null} rank
+ * @returns {string[]}
+ */
+export function sortFeaturedLabelsFirst(labels = [], rank = new Map()) {
+  return [...labels].sort((a, b) => (rank.get(a) ?? Infinity) - (rank.get(b) ?? Infinity))
+}
+
+/**
  * Build a human-readable platform statement for cards.
  * Input is already canonicalized (lowercase tokens like macos/linux/windows/any).
  */
@@ -591,6 +603,37 @@ if (import.meta.vitest) {
         { platforms: ['linux'] },
       ]
       expect(computePlatformLabelsForSearch(releases)).toEqual(['any'])
+    })
+  })
+
+  describe('sortFeaturedLabelsFirst', () => {
+    const featured = ['language syntax', 'snippets', 'linting', 'auto-complete', 'color scheme', 'theme']
+    const rank = new Map(featured.map((label, index) => [label, index]))
+
+    it('moves featured labels to the front using featured list order', () => {
+      const labels = ['zzz', 'theme', 'aaa', 'snippets', 'linting', 'bbb', 'language syntax']
+      expect(sortFeaturedLabelsFirst(labels, rank)).toEqual([
+        'language syntax',
+        'snippets',
+        'linting',
+        'theme',
+        'zzz',
+        'aaa',
+        'bbb',
+      ])
+    })
+
+    it('keeps non-featured labels in original relative order', () => {
+      const labels = ['one', 'snippets', 'two', 'language syntax', 'three', 'theme', 'four']
+      expect(sortFeaturedLabelsFirst(labels, rank)).toEqual([
+        'language syntax',
+        'snippets',
+        'theme',
+        'one',
+        'two',
+        'three',
+        'four',
+      ])
     })
   })
 


### PR DESCRIPTION
Keep manually picked featured labels at the front while preserving an explicit order among them.

Move the sorting logic into util.sortFeaturedLabelsFirst() and add unit tests that verify:
- featured labels are ordered by the provided featured list
- non-featured labels keep their original relative order