### PR TITLE
Prevent avg lines from stealing chart hover

### DIFF
--- a/static/style/chart.css
+++ b/static/style/chart.css
@@ -180,6 +180,7 @@ section:has(.chart-container)::after {
     opacity: 0.6;
     stroke-width: 1;
     stroke-dasharray: 2 1;
+    pointer-events: none;
   }
   .avg-line-net {
     opacity: 1;


### PR DESCRIPTION
The install chart's horizontal average lines were receiving pointer hover, which could interrupt week/release hover state transitions.

Just set avg-line pointer-events to none.