### PR TITLE
Fix newest version hiccup in the status chart

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -33,7 +33,6 @@ const MAGIC_WEIGHTS = {
   longevity: 0.1,
   recency: 0.05,
 }
-const STATUS_TAG_WINDOW_DAYS = 30
 const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
 
 const clamp01 = value => Math.max(0, Math.min(1, value))
@@ -96,29 +95,6 @@ function toTimestamp(value) {
   return Number.isNaN(parsed) ? null : parsed
 }
 
-function collectStatusTagData({ days = STATUS_TAG_WINDOW_DAYS } = {}) {
-  const cutoff = Date.now() - days * MS_IN_DAY
-  const semverTags = readStatusSemverTags()
-
-  const windowTags = []
-  let overflowTag = null
-
-  for (const tag of semverTags) {
-    const ts = Date.parse(tag.date)
-    if (!Number.isFinite(ts)) continue
-
-    if (ts >= cutoff) {
-      windowTags.push(tag)
-      continue
-    }
-
-    overflowTag = tag
-    break
-  }
-
-  return { windowTags, overflowTag }
-}
-
 function readStatusSemverTags() {
   const git = spawnSync(
     'git',
@@ -145,6 +121,10 @@ function readStatusSemverTags() {
     })
     .filter(({ tag, date }) => tag && date)
     .filter(({ tag }) => SEMVER_TAG_RE.test(tag))
+    // The 30-day chart only needs in-window tags plus the newest older tag for
+    // the left-edge overflow marker. Keep a generous count cap so this payload
+    // cannot grow unbounded while still covering busy release periods.
+    .slice(0, 30)
 }
 
 function computeMagicMetadata(packages) {
@@ -577,12 +557,11 @@ export default function (eleventyConfig) {
     disableLiveLink: Boolean(process.env.DISABLE_L_LINK),
   })
 
-  const statusTagData = collectStatusTagData()
+  // Send the full tag history so the browser can decide what is visible and
+  // what belongs behind the left-edge overflow pointer using the current day.
+  const statusTags = readStatusSemverTags()
   eleventyConfig.addGlobalData('status_tag_dates_json', () => {
-    return JSON.stringify(statusTagData.windowTags)
-  })
-  eleventyConfig.addGlobalData('status_tag_overflow_json', () => {
-    return statusTagData.overflowTag ? JSON.stringify(statusTagData.overflowTag) : 'null'
+    return JSON.stringify(statusTags)
   })
 
   // Default permalink: output files with their extension (e.g., /page.html)

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -34,6 +34,7 @@ const MAGIC_WEIGHTS = {
   recency: 0.05,
 }
 const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
+const STATUS_TAG_WINDOW_DAYS = 30
 
 const clamp01 = value => Math.max(0, Math.min(1, value))
 // GitHub-style emoji shortcode mapping, loaded from JSON.
@@ -113,7 +114,7 @@ function readStatusSemverTags() {
     return []
   }
 
-  return git.stdout
+  const semverTags = git.stdout
     .split(/\r?\n/)
     .map((line) => {
       const [tag, taggerDate] = line.split('\t')
@@ -121,10 +122,27 @@ function readStatusSemverTags() {
     })
     .filter(({ tag, date }) => tag && date)
     .filter(({ tag }) => SEMVER_TAG_RE.test(tag))
-    // The 30-day chart only needs in-window tags plus the newest older tag for
-    // the left-edge overflow marker. Keep a generous count cap so this payload
-    // cannot grow unbounded while still covering busy release periods.
-    .slice(0, 30)
+    .filter(({ date }) => Number.isFinite(Date.parse(date)))
+
+  return statusTagsForChartWindow(semverTags)
+}
+
+function statusTagsForChartWindow(tags, {
+  days = STATUS_TAG_WINDOW_DAYS,
+  nowTimestamp = Date.now(),
+} = {}) {
+  const cutoff = nowTimestamp - Math.max(0, Math.floor(days)) * MS_IN_DAY
+  const selected = []
+
+  for (const tag of tags) {
+    // The status chart needs tags in its visible day window plus exactly the
+    // newest older tag for the left-edge overflow marker.
+    // Hence break after push.
+    selected.push(tag)
+    if (Date.parse(tag.date) < cutoff) break
+  }
+
+  return selected
 }
 
 function computeMagicMetadata(packages) {

--- a/static/module/status-tags.js
+++ b/static/module/status-tags.js
@@ -1,0 +1,36 @@
+import { dayIndexForTimestamp, localDayId, safeDate } from './status-day.js'
+
+/**
+ * Find the newest release tag that is older than the chart's visible day
+ * window. This lets the chart render an overflow pointer based on the
+ * viewer's current date instead of a build-time cutoff.
+ *
+ * @template {{ date?: string }} T
+ * @param {T[]} markers
+ * @param {number} days
+ * @param {{ nowTimestamp?: number }} [options]
+ * @returns {T | null}
+ */
+export function newestTagBeforeDayWindow(markers, days, {
+  nowTimestamp = Date.now(),
+} = {}) {
+  const maxDays = Number.isFinite(days) ? Math.max(0, Math.floor(days)) : 0
+  const anchorDayId = localDayId(nowTimestamp)
+  let newest = null
+  let newestTimestamp = 0
+
+  for (const marker of markers || []) {
+    const ts = safeDate(marker?.date)
+    if (!ts) continue
+
+    const dayIndex = dayIndexForTimestamp(ts, anchorDayId)
+    if (!Number.isFinite(dayIndex) || dayIndex < maxDays) continue
+
+    if (!newest || ts > newestTimestamp) {
+      newest = marker
+      newestTimestamp = ts
+    }
+  }
+
+  return newest
+}

--- a/static/module/status-tags.test.js
+++ b/static/module/status-tags.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { newestTagBeforeDayWindow } from './status-tags.js'
+import { shiftTimestampByLocalDays } from './status-day.js'
+
+function isoDaysBefore(now, daysAgo) {
+  return new Date(shiftTimestampByLocalDays(now, -daysAgo)).toISOString()
+}
+
+describe('status tag helpers', () => {
+  it('finds the newest tag before the visible chart window', () => {
+    const now = Date.parse('2026-04-30T12:00:00Z')
+    const marker = newestTagBeforeDayWindow([
+      { tag: '0.13.1', date: isoDaysBefore(now, 35) },
+      { tag: '0.14.0', date: isoDaysBefore(now, 30) },
+      { tag: '0.15.0', date: isoDaysBefore(now, 10) },
+    ], 30, { nowTimestamp: now })
+
+    expect(marker?.tag).toBe('0.14.0')
+  })
+
+  it('returns null when all tags are inside the visible chart window', () => {
+    const now = Date.parse('2026-04-30T12:00:00Z')
+    const marker = newestTagBeforeDayWindow([
+      { tag: '0.15.0', date: isoDaysBefore(now, 0) },
+      { tag: '0.14.0', date: isoDaysBefore(now, 29) },
+    ], 30, { nowTimestamp: now })
+
+    expect(marker).toBeNull()
+  })
+
+  it('ignores invalid and future marker dates', () => {
+    const now = Date.parse('2026-04-30T12:00:00Z')
+    const marker = newestTagBeforeDayWindow([
+      { tag: 'bad', date: 'nope' },
+      { tag: 'future', date: isoDaysBefore(now, -1) },
+      { tag: 'old', date: isoDaysBefore(now, 31) },
+    ], 30, { nowTimestamp: now })
+
+    expect(marker?.tag).toBe('old')
+  })
+})

--- a/static/status.js
+++ b/static/status.js
@@ -17,6 +17,7 @@ import {
   normalizePackageNameKey,
   normalizeStatusNotes,
 } from './module/status-failing.js'
+import { newestTagBeforeDayWindow } from './module/status-tags.js'
 import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify/dist/purify.es.mjs'
 import { marked } from 'https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js'
 
@@ -27,7 +28,6 @@ const badgeEl = document.querySelector('[data-status-badge]')
 const badgeLabelEl = document.querySelector('[data-status-label]')
 const chartEl = document.querySelector('[data-status-chart]')
 const tagDataEl = document.querySelector('[data-status-tag-dates]')
-const overflowTagDataEl = document.querySelector('[data-status-tag-overflow]')
 /** @type {HTMLButtonElement | null} */
 const prevButton = document.querySelector('[data-control="prev"]')
 /** @type {HTMLButtonElement | null} */
@@ -55,20 +55,14 @@ const lastButton = document.querySelector('[data-control="last"]')
  */
 
 /**
- * Release marker rendered at the chart top for tags that fall inside the
- * currently visible day window.
+ * Release marker used by the chart. Markers inside the current day window are
+ * rendered at the chart top; the newest marker before the window is rendered as
+ * an overflow pointer.
  *
  * @typedef {{
  *    tag: string,
  *    date: string,
  *  }} TagMarker
- */
-
-/**
- * A "just before the window" tag rendered as a left-pointing overflow
- * indicator outside the visible chart range.
- *
- * @typedef {TagMarker} OverflowTagMarker
  */
 
 /** @type {LogEntry[]} */
@@ -79,13 +73,6 @@ let chart = null
 let emptyStateMessage = ''
 /** @type {TagMarker[]} */
 const tagMarkers = loadTagMarkers(tagDataEl)
-/**
- * Optional tag marker that points to the most recent tag just before the
- * visible window. Rendered as an external left-side indicator.
- *
- * @type {OverflowTagMarker | null}
- */
-const overflowTagMarker = loadOverflowTagMarker(overflowTagDataEl)
 
 function init() {
   if (!notesEl || !dateEl || !badgeEl) {
@@ -98,7 +85,6 @@ function init() {
       onHover: showHoverPreview,
     })
     chart.setTagMarkers(tagMarkers)
-    chart.setOverflowTagMarker(overflowTagMarker)
     chartEl.addEventListener('mouseleave', restoreActiveEntry)
   }
 
@@ -642,7 +628,6 @@ class StatusChart {
     this.points = []
     this.entries = []
     this.tagMarkers = []
-    this.overflowTagMarker = null
     this.gridAnchorDayKey = currentLocalDayKey()
 
     this.resizeObserver = new ResizeObserver(() => this.layout())
@@ -769,11 +754,6 @@ class StatusChart {
 
   setTagMarkers(markers) {
     this.tagMarkers = markers || []
-    this.redrawDots()
-  }
-
-  setOverflowTagMarker(marker) {
-    this.overflowTagMarker = marker || null
     this.redrawDots()
   }
 
@@ -1011,7 +991,8 @@ class StatusChart {
    * labels/lines, because the left edge would become visually crowded.
    */
   drawOverflowTagMarker() {
-    if (!this.overflowTagMarker) return
+    const overflowTagMarker = newestTagBeforeDayWindow(this.tagMarkers, this.days)
+    if (!overflowTagMarker) return
     if (this.hasTagMarkersInOldestDays()) {
       return
     }
@@ -1056,10 +1037,10 @@ class StatusChart {
     label.setAttribute('class', 'tag-overflow-label')
     label.setAttribute('x', String(crisp(shaftEndX + labelGap)))
     label.setAttribute('y', String(crisp(labelY)))
-    label.textContent = this.overflowTagMarker.tag
+    label.textContent = overflowTagMarker.tag
 
     const title = document.createElementNS('http://www.w3.org/2000/svg', 'title')
-    title.textContent = formatTagDateShort(this.overflowTagMarker.date)
+    title.textContent = formatTagDateShort(overflowTagMarker.date)
     label.appendChild(title)
 
     group.appendChild(label)
@@ -1245,33 +1226,6 @@ function loadTagMarkers(el) {
   catch (err) {
     console.warn('Failed to parse status tag markers:', err)
     return []
-  }
-}
-
-/**
- * Parse the optional overflow marker from inline JSON data.
- *
- * @param {Element | null} el
- * @returns {OverflowTagMarker | null}
- */
-function loadOverflowTagMarker(el) {
-  if (!el || !el.textContent) return null
-
-  try {
-    const raw = JSON.parse(el.textContent)
-    if (!raw || typeof raw !== 'object') return null
-
-    const tag = String(raw.tag || '').trim()
-    const date = String(raw.date || '').trim()
-    if (!tag || !date) return null
-    if (!isSemverTag(tag)) return null
-    if (!safeDate(date)) return null
-
-    return { tag, date }
-  }
-  catch (err) {
-    console.warn('Failed to parse status overflow tag marker:', err)
-    return null
   }
 }
 

--- a/status.njk
+++ b/status.njk
@@ -42,8 +42,4 @@ description: "Latest crawler runs and notes."
 {{ (status_tag_dates_json or '[]') | safe }}
 </script>
 
-<script type="application/json" data-status-tag-overflow>
-{{ (status_tag_overflow_json or 'null') | safe }}
-</script>
-
 <script src="{{ '/static/status.js' | bust }}" type="module" async></script>


### PR DESCRIPTION
We basically computed what `newestTagBeforeDayWindow` now does on build
time.  Naturally, this gets out-of-sync if the live chart advances
before a next rebuild.

The fix is to compute it "live", client-side.