### PR TITLE
Release callout hiccup

### DIFF
--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -316,7 +316,7 @@ export function release_week_model(releases, dates, max_week_idx) {
   }
 
   const weeks = []
-  const versionsByWeek = new Map()
+  const releasesByWeek = new Map()
 
   for (const release of releases) {
     if (!release || !release.date) continue
@@ -324,23 +324,42 @@ export function release_week_model(releases, dates, max_week_idx) {
     if (idx === null || idx === undefined) continue
     if (idx >= max_week_idx) continue
 
-    if (!versionsByWeek.has(idx)) {
+    if (!releasesByWeek.has(idx)) {
       weeks.push(idx)
-      versionsByWeek.set(idx, [])
+      releasesByWeek.set(idx, [])
     }
 
+    releasesByWeek.get(idx).push(release)
+  }
+
+  return weeks.map(week_idx => ({
+    week_idx,
+    versions: releaseVersionsForWeek(releasesByWeek.get(week_idx) ?? []),
+  }))
+}
+
+function releaseVersionsForWeek(releases) {
+  const sortedReleases = [...releases].sort((a, b) => {
+    const maxA = util.parseSublimeTextMax(a?.sublime_text)
+    const maxB = util.parseSublimeTextMax(b?.sublime_text)
+    if (maxA !== maxB) {
+      return maxB - maxA
+    }
+
+    const dateA = new Date(a?.date ?? '1970-01-01 00:00:00')
+    const dateB = new Date(b?.date ?? '1970-01-01 00:00:00')
+    return dateB - dateA
+  })
+
+  const versions = []
+  for (const release of sortedReleases) {
     const version = String(release.version ?? 'unknown')
-    const week = versionsByWeek.get(idx)
-    if (!week.includes(version)) {
-      week.push(version)
+    if (!versions.includes(version)) {
+      versions.push(version)
     }
   }
 
-  const versions_list = weeks.map(idx => versionsByWeek.get(idx) ?? [])
-  return weeks.map((week_idx, i) => ({
-    week_idx,
-    versions: versions_list[i],
-  }))
+  return versions
 }
 
 // for each week index, find the nearest release week index
@@ -599,19 +618,19 @@ if (import.meta.vitest) {
   })
 
   describe('release_week_model', () => {
-    it('deduplicates versions in each release week', () => {
+    it('sorts and deduplicates versions in each release week', () => {
       const releases = [
-        { date: '2026-04-22T18:02:46Z', version: '6.1.0' },
-        { date: '2026-04-22T18:02:27Z', version: '5.1.0' },
-        { date: '2026-04-22T15:17:35Z', version: '6.0.0' },
-        { date: '2026-04-20T00:27:09Z', version: '5.0.3' },
-        { date: '2026-04-20T00:27:09Z', version: '5.0.3' },
+        { date: '2026-04-22T18:02:46Z', sublime_text: '>=4204', version: '6.1.0' },
+        { date: '2026-04-22T18:02:27Z', sublime_text: '4107 - 4203', version: '5.1.0' },
+        { date: '2026-04-22T15:17:35Z', sublime_text: '>=4204', version: '6.0.0' },
+        { date: '2026-04-20T00:27:09Z', sublime_text: '4107 - 4203', version: '5.0.3' },
+        { date: '2026-04-20T00:27:09Z', sublime_text: '>=4204', version: '5.0.3' },
       ]
 
       expect(release_week_model(releases, ['2026-W17'], 1)).toStrictEqual([
         {
           week_idx: 0,
-          versions: ['6.1.0', '5.1.0', '6.0.0', '5.0.3'],
+          versions: ['6.1.0', '6.0.0', '5.0.3', '5.1.0'],
         },
       ])
     })

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -329,8 +329,11 @@ export function release_week_model(releases, dates, max_week_idx) {
       versionsByWeek.set(idx, [])
     }
 
-    const version = release.version ?? 'unknown'
-    versionsByWeek.get(idx).push(String(version))
+    const version = String(release.version ?? 'unknown')
+    const week = versionsByWeek.get(idx)
+    if (!week.includes(version)) {
+      week.push(version)
+    }
   }
 
   const versions_list = weeks.map(idx => versionsByWeek.get(idx) ?? [])
@@ -592,6 +595,25 @@ if (import.meta.vitest) {
       const monday = new Date(ymd + 'T00:00:00Z')
       expect(monday.getUTCDay()).toBe(1)
       expect(day_offset_of_month_change(monday)).toBe(expected)
+    })
+  })
+
+  describe('release_week_model', () => {
+    it('deduplicates versions in each release week', () => {
+      const releases = [
+        { date: '2026-04-22T18:02:46Z', version: '6.1.0' },
+        { date: '2026-04-22T18:02:27Z', version: '5.1.0' },
+        { date: '2026-04-22T15:17:35Z', version: '6.0.0' },
+        { date: '2026-04-20T00:27:09Z', version: '5.0.3' },
+        { date: '2026-04-20T00:27:09Z', version: '5.0.3' },
+      ]
+
+      expect(release_week_model(releases, ['2026-W17'], 1)).toStrictEqual([
+        {
+          week_idx: 0,
+          versions: ['6.1.0', '5.1.0', '6.0.0', '5.0.3'],
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
Avoid showing the same version more than once in a release week
callout when separate release entries share a version.  They can do so
for different environments (e.g. `sublime_text` variants).

Also apply "some" sorting.

<img width="209" height="164" alt="image" src="https://github.com/user-attachments/assets/2af055a8-77de-4d6e-bb4e-7f2d816cd63b" />

T.i. newer `sublime_text` build first, otherwise by date.

Before:

<img width="201" height="112" alt="image" src="https://github.com/user-attachments/assets/ce48b671-d599-4583-86d7-035c1c101724" />
