### PR TITLE
Fix: GitLab branch URL points to HTML tree instead of zip archive

### DIFF
--- a/scripts/gitlab.py
+++ b/scripts/gitlab.py
@@ -213,7 +213,10 @@ class BranchesPager(_Pager):
                     continue
                 new_branches.append({
                     "name": branch["name"],
-                    "url": f"https://gitlab.com/{self.owner}/{self.repo}/-/tree/{branch['name']}",
+                    "url": (
+                        f"https://gitlab.com/{self.owner}/{self.repo}"
+                        f"/-/archive/{branch['name']}/{self.repo}-{branch['name']}.zip"
+                    ),
                     "date": normalize_tz_aware_datetime(raw_date),
                 })
             self._cache.extend(new_branches)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -92,7 +92,10 @@ async def test_fetch_gitlab_info_formats_datetimes(monkeypatch):
     assert branches_out == [
         {
             "name": "master",
-            "url": "https://gitlab.com/jiehong/sublime_jq/-/tree/master",
+            "url": (
+                "https://gitlab.com/jiehong/sublime_jq/-/archive/"
+                "master/sublime_jq-master.zip"
+            ),
             "date": "2023-02-13T18:08:53Z",
         }
     ]


### PR DESCRIPTION
Closes #369.

## Problem

`BranchesPager` in `scripts/gitlab.py` constructs each branch's `url` as `https://gitlab.com/{owner}/{repo}/-/tree/{branch}`. That endpoint returns HTML, not a downloadable archive.

Downstream consumers that try to fetch and unzip the URL (e.g. `kaste/st_package_reviewer`'s tags-mode default-branch-tip review) fail with:

```
End-of-central-directory signature not found.
unzip: cannot find zipfile directory in .../pkg.zip
! Unzip failed for D2@2026.04.28.21.00.28
```

Observed in sublimehq/package_control_channel#9396 (CI run: https://github.com/sublimehq/package_control_channel/actions/runs/25077655912/job/73835092978).

The tag path (`TagPager`) already uses the correct archive URL pattern, so only branches were affected.

## Fix

Build the same archive URL shape GitLab serves zips from:

```python
"url": (
    f"https://gitlab.com/{self.owner}/{self.repo}"
    f"/-/archive/{branch['name']}/{self.repo}-{branch['name']}.zip"
)
```

Verified manually:

- `https://gitlab.com/sotilrac/d2-syntax/-/tree/main` -> `200 OK`, `content-type: text/html`
- `https://gitlab.com/sotilrac/d2-syntax/-/archive/main/d2-syntax-main.zip` -> `200 OK`, `content-type: application/zip`

## Tests

Updated `tests/test_gitlab.py::test_fetch_gitlab_info_formats_datetimes` to expect the archive URL. Full suite (`uv run pytest`) passes: 376 passed.
