### PR TITLE
wrap platform statement if needed

### DIFF
--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -135,6 +135,7 @@ section[name="labels"] .grid {
       padding: 0;
       cursor: default;
       white-space: revert;
+      word-break: keep-all;
       &:hover {
         background: transparent;
       }
@@ -144,6 +145,14 @@ section[name="labels"] .grid {
   .list & .labels {
     justify-content: flex-start;
     margin-top: 21px;  /* usually collapses with margin-bottom from .description */
+  }
+
+  .list & .platforms {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    max-width: max(100px, 30vw);
   }
 
   .list & .stats {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -134,6 +134,7 @@ section[name="labels"] .grid {
       margin: 0;
       padding: 0;
       cursor: default;
+      white-space: revert;
       &:hover {
         background: transparent;
       }

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -72,7 +72,7 @@ ul.stats {
   display: flex;
   gap: 1em;
   align-content: center;
-  align-items: center;
+  align-items: baseline;
   line-height: 28px;
   padding-left: 0;
   color: var(--foreground-2);
@@ -88,6 +88,10 @@ ul.stats {
 
   a {
     color: inherit;
+  }
+
+  .platforms {
+    word-break: keep-all;
   }
 }
 


### PR DESCRIPTION
Before:

<img width="390" height="151" alt="Scherm­afbeelding 2026-05-06 om 20 42 05" src="https://github.com/user-attachments/assets/9b009caa-c6bb-425c-9bf5-8540dee4308d" />

After:

<img width="387" height="170" alt="Scherm­afbeelding 2026-05-06 om 20 39 42" src="https://github.com/user-attachments/assets/1e9d3da0-ff12-40c4-b22e-fee24575878f" />

As reported by @michaelblyons in https://github.com/packagecontrol/thecrawl/issues/56#issuecomment-4390844413