### PR TITLE
Improve platform statement wrapping

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -55,12 +55,7 @@
 {% endmacro %}
 
 {% macro labels(pkg, with_icons=false, platform_statement='') %}
-  {% set buttons -%}
-    {%- if platform_statement -%}
-      <li class="platform-statement-wrap">
-        <span class="button label platform-statement">{{ platform_statement }}</span>
-      </li>
-    {%- endif -%}
+  {% set label_buttons -%}
     {%- for label in pkg.labels %}
       {% set q = searchQueryFor('label', label) %}
       <li>
@@ -102,6 +97,24 @@
         {% endif %}
       </li>
     {%- endfor -%}
+  {%- endset %}
+
+  {% set buttons -%}
+    {%- if platform_statement -%}
+      {% set separator_count = (platform_statement | replace('/', '//') | length) - (platform_statement | length) %}
+      <li class="platform-statement-wrap{{ ' platform-statement-wrap-enumeration' if separator_count >= 2 }}">
+        <span class="button label platform-statement">{{ platform_statement }}</span>
+      </li>
+      {%- if label_buttons | trim -%}
+        <li class="package-labels-wrap">
+          <ul class="package-labels">
+            {{ label_buttons | safe }}
+          </ul>
+        </li>
+      {%- endif -%}
+    {%- else -%}
+      {{ label_buttons | safe }}
+    {%- endif -%}
   {%- endset %}
 
   {% if buttons | trim %}

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -152,20 +152,22 @@
 
 {% macro card(pkg, mark_as_main=false, platform_in_labels=false) %}
   <div class="card{{ ' dimmed' if pkg.outdated }}">
-    <h3>
-      <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
-        {{- pkg.name -}}
-      </a>
-    </h3>
+    <div class="card-heading">
+      <h3>
+        <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
+          {{- pkg.name -}}
+        </a>
+      </h3>
 
-    {% if pkg.author and (pkg.author | length) > 0 %}
-      <p class="authors">by
-      {% for author in pkg.author -%}
-        {% set q = searchQueryFor('author', author) %}
-        <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
-      {%- endfor %}
-      </p>
-    {% endif %}
+      {% if pkg.author and (pkg.author | length) > 0 %}
+        <p class="authors">by
+        {% for author in pkg.author -%}
+          {% set q = searchQueryFor('author', author) %}
+          <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
+        {%- endfor %}
+        </p>
+      {% endif %}
+    </div>
 
     {% if pkg.description %}
       <p class="description">

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -3,6 +3,7 @@ import path from 'path'
 import { execSync } from 'child_process'
 
 const isProd = process.env.NODE_ENV === 'production' || process.env.ELEVENTY_ENV === 'production'
+const NBSP = '\u00A0'
 
 const canonicalizeOs = (platform) => {
   const lower = platform.toLowerCase()
@@ -158,16 +159,20 @@ export function computePlatformStatement(platforms) {
 
   if (collapsed.length === 1 && collapsed[0].kind === 'variant') {
     const token = collapsed[0]
-    return `Only on ${prettifyOs(token.os)}-${token.variant}`
+    return `Only on ${platformTokenLabel(token)}`
   }
 
-  const labels = collapsed.map((token) => {
-    if (token.kind === 'base') return prettifyOs(token.os)
-    if (token.kind === 'variant') return `${prettifyOs(token.os)}-${token.variant}`
-    return token.raw
-  })
+  const labels = collapsed.map(platformTokenLabel)
 
-  return labels.join('/')
+  // Keep the slash with the preceding platform when wrapping.
+  return labels.join(`${NBSP}/ `)
+}
+
+function platformTokenLabel(token) {
+  if (token.kind === 'base') return prettifyOs(token.os)
+  if (token.kind === 'variant') return `${prettifyOs(token.os)}‑${token.variant}`
+  // Replace normal hyphens to non-breaking hyphens
+  return token.raw.replaceAll('-', '‑')
 }
 
 /**
@@ -823,9 +828,9 @@ if (import.meta.vitest) {
       [['linux-x32', 'linux-x64'], 'Only for Linux'],
       [['linux-x32', 'linux-x64', 'windows'], 'Not for macOS'],
 
-      [['windows-x64'], 'Only on Windows-x64'],
-      [['linux-x32', 'windows-x32'], 'Linux-x32/Windows-x32'],
-      [['linux-arm64'], 'Only on Linux-arm64'],
+      [['windows-x64'], 'Only on Windows‑x64'],
+      [['linux-x32', 'windows-x32'], 'Linux‑x32\u00A0/ Windows‑x32'],
+      [['linux-arm64'], 'Only on Linux‑arm64'],
     ])('computePlatformStatement(%j) -> %j', (input, expected) => {
       expect(computePlatformStatement(input)).toBe(expected)
     })

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -35,7 +35,7 @@ export class Card {
     // clear the placeholder then fill with data
     labels.innerHTML = ''
     this.platforms()
-    this.labels(labels)
+    this.labels(this.labelParent(labels))
     this.stats()
 
     return this.clone
@@ -188,6 +188,9 @@ export class Card {
       }
       const li = document.createElement('li')
       li.classList.add('platform-statement-wrap')
+      if (this.countPlatformSeparators(label) >= 2) {
+        li.classList.add('platform-statement-wrap-enumeration')
+      }
 
       const span = document.createElement('span')
       span.classList.add('button', 'label', 'platform-statement')
@@ -211,6 +214,26 @@ export class Card {
     li.textContent = label
 
     return li
+  }
+
+  countPlatformSeparators(label) {
+    return label.split('/').length - 1
+  }
+
+  labelParent(parent) {
+    if (!this.compact || this.pkg.labels.length < 1 || !this.pkg.platform_statement?.trim()) {
+      return parent
+    }
+
+    const li = document.createElement('li')
+    li.classList.add('package-labels-wrap')
+
+    const nested = document.createElement('ul')
+    nested.classList.add('package-labels')
+    li.appendChild(nested)
+    parent.appendChild(li)
+
+    return nested
   }
 
   labels(parent) {

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -20,8 +20,8 @@ export class Card {
       this.insertDebugComment(cardRoot)
     }
 
-    this.clone.querySelector('a').innerHTML = this.pkg.name
-    this.clone.querySelector('a').setAttribute('href', this.pkg.permalink)
+    this.clone.querySelector('.card-heading a').innerHTML = this.pkg.name
+    this.clone.querySelector('.card-heading a').setAttribute('href', this.pkg.permalink)
     this.authors(this.clone.querySelector('p.authors'))
 
     const descr_el = this.clone.querySelector('p.description')
@@ -37,8 +37,21 @@ export class Card {
     this.platforms()
     this.labels(this.labelParent(labels))
     this.stats()
+    this.positionStats()
 
     return this.clone
+  }
+
+  positionStats() {
+    if (this.compact) {
+      return
+    }
+
+    const heading = this.clone.querySelector('.card-heading')
+    const stats = this.clone.querySelector('ul.stats')
+    if (heading && stats) {
+      heading.appendChild(stats)
+    }
   }
 
   insertDebugComment(cardRoot) {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -134,6 +134,7 @@ section[name="labels"] .grid {
       margin: 0;
       padding: 0;
       cursor: default;
+      white-space: revert;
       &:hover {
         background: transparent;
       }

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -133,7 +133,8 @@ section[name="labels"] .grid {
       column-gap: 7px;
 
       &:has(> .platform-statement-wrap-enumeration) {
-        grid-template-columns: minmax(0, 1fr) max-content;
+        grid-template-columns: 1fr;
+        row-gap: 10px;
       }
     }
     .platform-statement {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -126,8 +126,15 @@ section[name="labels"] .grid {
       line-height: 20px;
       padding: 1px 6px;
     }
-    .platform-statement-wrap {
-      flex: 1 1 auto;
+    &:has(> .platform-statement-wrap > .platform-statement):has(> .package-labels-wrap) {
+      display: grid;
+      grid-template-columns: max-content minmax(0, 1fr);
+      align-items: end;
+      column-gap: 7px;
+
+      &:has(> .platform-statement-wrap-enumeration) {
+        grid-template-columns: minmax(0, 1fr) max-content;
+      }
     }
     .platform-statement {
       background: transparent;
@@ -138,6 +145,20 @@ section[name="labels"] .grid {
       &:hover {
         background: transparent;
       }
+    }
+    .package-labels-wrap {
+      justify-self: end;
+      max-width: 100%;
+    }
+    .package-labels {
+      display: flex;
+      gap: 7px;
+      justify-content: flex-end;
+      align-items: end;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0;
     }
   }
 

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -63,26 +63,28 @@ section[name="labels"] .grid {
     outline: 2px solid var(--orange-1);
   }
 
-  h3 {
-    color: var(--foreground-1);
-    padding-top: 0;
+  .card-heading {
     padding-right: 3.2em;
-    margin-top: 0;
-    margin-bottom: 2px;
-    overflow-wrap: anywhere;
-
-    + * {
-      padding-top: 0;
-      margin-top: 0;
-      flex: 1; /* push other content to the end of the card */
-    }
   }
-  &:has(.stats .warning) h3 {
+
+  .grid & .card-heading {
+    flex: 1; /* push other content to the end of the card */
+  }
+
+  .authors {
+    padding-top: 0;
+    margin-bottom: 16px;
+  }
+  &:has(.stats .warning) .card-heading {
     padding-right: 4.8em;
   }
 
   h3 {
     color: var(--foreground-3);
+    padding-top: 0;
+    margin-top: 0;
+    margin-bottom: 2px;
+    overflow-wrap: anywhere;
   }
 
   h3 a,
@@ -93,7 +95,7 @@ section[name="labels"] .grid {
     }
   }
 
-  p:last-child {
+  > p:last-child {
     margin-bottom: 0;
   }
 
@@ -168,19 +170,37 @@ section[name="labels"] .grid {
     margin-top: 21px;  /* usually collapses with margin-bottom from .description */
   }
 
-  .list & .stats {
-    @media (min-width: 480px) {
-      flex-direction: row-reverse;
-      gap: 1em;
+  .list & .card-heading {
+    padding-right: calc(min(38vw, 18rem) + 1rem);
+    position: relative;
+  }
 
-      .platforms {
-        position: absolute;
-        right: 0;
-        top: 1.75em;
-        width: auto;
-        white-space: nowrap;
-        text-align: right;
-      }
+  .list & .stats {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: flex-start;
+    column-gap: 1em;
+    position: absolute;
+    right: 0;
+    top: 2px;
+    width: min(38vw, 18rem);
+
+    .stars {
+      order: 1;
+    }
+    .installs {
+      order: 2;
+    }
+    .platforms {
+      display: block;
+      flex-basis: 100%;
+      order: 3;
+      line-height: 1.25;
+      white-space: revert;
+      text-align: right;
+      margin-top: 4px;
     }
   }
 

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -91,6 +91,10 @@ ul.stats {
   }
 }
 
+section[name="package"] > ul.stats .platforms {
+  max-width: 60%;
+}
+
 .other-releases {
 
   summary {

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -72,7 +72,7 @@ ul.stats {
   display: flex;
   gap: 1em;
   align-content: center;
-  align-items: center;
+  align-items: baseline;
   line-height: 28px;
   padding-left: 0;
   color: var(--foreground-2);


### PR DESCRIPTION
Allow platform statements in card labels to wrap naturally and align
stats text on the package details page by baseline.

To make that work for the search results page, we really need a different structure.  (Short: Make the top of the card a two column layout.)

This need a refactoring PR later as we have "one" card that actually doesn't share that much, a compact one the landing page and a search result card/entry/item.  Also: platform statements are neither labels nor buttons.  These are non-interactive metadata text.  In the sense `white-space: revert` hacks around already.  

<img width="682" height="533" alt="image" src="https://github.com/user-attachments/assets/8c200722-a12e-4dcf-912b-d14b035f1530" />

<img width="769" height="534" alt="image" src="https://github.com/user-attachments/assets/6a3e8069-9296-402a-9f1b-532d16d363d0" />

<img width="411" height="398" alt="image" src="https://github.com/user-attachments/assets/328fc01b-12df-4890-b82a-67a6672ccc79" />

These all look better now aligned to the corner.   