### PR TITLE
Card labels and buttons refactor

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -54,6 +54,87 @@
   {% endif %}
 {% endmacro %}
 
+{% macro compact_card(pkg, mark_as_main=false) %}
+  <div class="card card-compact{{ ' dimmed' if pkg.outdated }}">
+    <div class="card-heading">
+      {{ card_identity(pkg, mark_as_main) }}
+    </div>
+
+    <ul class="stats">
+      {{ installs(pkg.installed, true) }}
+      {{ stars(pkg.stars, true) }}
+    </ul>
+    {{ labels(pkg, true, pkg.platform_statement) }}
+  </div>
+{% endmacro %}
+
+{% macro search_result_card(pkg, mark_as_main=false) %}
+  <div class="card card-result{{ ' dimmed' if pkg.outdated }}">
+    <div class="card-heading">
+      <div>
+        {{ card_identity(pkg, mark_as_main) }}
+      </div>
+
+      <ul class="stats">
+        {{ installs(pkg.installed, true) }}
+        {{ stars(pkg.stars, true) }}
+        {{ platforms(pkg.platform_statement) }}
+      </ul>
+    </div>
+
+    {% if pkg.description %}
+      <p class="description">
+        {{ pkg.description }}
+      </p>
+    {% endif %}
+
+    {{ labels(pkg, true) }}
+  </div>
+{% endmacro %}
+
+{% macro card_identity(pkg, mark_as_main=false) %}
+  <h3>
+    <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
+      {{- pkg.name -}}
+    </a>
+  </h3>
+
+  {% if pkg.author and (pkg.author | length) > 0 %}
+    <p class="authors">by
+    {% for author in pkg.author -%}
+      {% set q = searchQueryFor('author', author) %}
+      <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
+    {%- endfor %}
+    </p>
+  {% endif %}
+{% endmacro %}
+
+{% macro installs(count, pretty=false) %}
+  {% if count > 0 %}
+    <li class="installs" title="Installed {{ count }} {{ 'time' if count < 2 else 'times' }}">
+      <span aria-hidden="true">{{ util.icon('download') }}</span>
+      <span class="counter">{{ (count | compact) if pretty else (count | grouping) }}</span>
+      <span class="screenreader-only">installs</span>
+    </li>
+  {% endif %}
+{% endmacro %}
+
+{% macro stars(count, pretty=false) %}
+  {% if count > 0 %}
+    <li class="stars" title="{{ count }} {{ 'star' if count < 2 else 'stars' }} on GitHub">
+      <span aria-hidden="true">{{ util.icon('star') }}</span>
+      <span class="counter">{{ (count | compact) if pretty else (count | grouping) }}</span>
+      <span class="screenreader-only">stars</span>
+    </li>
+  {% endif %}
+{% endmacro %}
+
+{% macro platforms(platform_statement) %}
+  {% if platform_statement %}
+    <li class="platforms">{{ platform_statement }}</li>
+  {% endif %}
+{% endmacro %}
+
 {% macro labels(pkg, with_icons=false, platform_statement='') %}
   {% set label_buttons -%}
     {%- for label in pkg.labels %}
@@ -121,86 +202,5 @@
     <ul class="button-group labels">
       {{ buttons | safe }}
     </ul>
-  {% endif %}
-{% endmacro %}
-
-{% macro platforms(platform_statement) %}
-  {% if platform_statement %}
-    <li class="platforms">{{ platform_statement }}</li>
-  {% endif %}
-{% endmacro %}
-
-{% macro stars(count, pretty=false) %}
-  {% if count > 0 %}
-    <li class="stars" title="{{ count }} {{ 'star' if count < 2 else 'stars' }} on GitHub">
-      <span aria-hidden="true">{{ util.icon('star') }}</span>
-      <span class="counter">{{ (count | compact) if pretty else (count | grouping) }}</span>
-      <span class="screenreader-only">stars</span>
-    </li>
-  {% endif %}
-{% endmacro %}
-
-{% macro installs(count, pretty=false) %}
-  {% if count > 0 %}
-    <li class="installs" title="Installed {{ count }} {{ 'time' if count < 2 else 'times' }}">
-      <span aria-hidden="true">{{ util.icon('download') }}</span>
-      <span class="counter">{{ (count | compact) if pretty else (count | grouping) }}</span>
-      <span class="screenreader-only">installs</span>
-    </li>
-  {% endif %}
-{% endmacro %}
-
-{% macro compact_card(pkg, mark_as_main=false) %}
-  <div class="card card-compact{{ ' dimmed' if pkg.outdated }}">
-    <div class="card-heading">
-      {{ card_identity(pkg, mark_as_main) }}
-    </div>
-
-    <ul class="stats">
-      {{ installs(pkg.installed, true) }}
-      {{ stars(pkg.stars, true) }}
-    </ul>
-    {{ labels(pkg, true, pkg.platform_statement) }}
-  </div>
-{% endmacro %}
-
-{% macro search_result_card(pkg, mark_as_main=false) %}
-  <div class="card card-result{{ ' dimmed' if pkg.outdated }}">
-    <div class="card-heading">
-      <div>
-        {{ card_identity(pkg, mark_as_main) }}
-      </div>
-
-      <ul class="stats">
-        {{ installs(pkg.installed, true) }}
-        {{ stars(pkg.stars, true) }}
-        {{ platforms(pkg.platform_statement) }}
-      </ul>
-    </div>
-
-    {% if pkg.description %}
-      <p class="description">
-        {{ pkg.description }}
-      </p>
-    {% endif %}
-
-    {{ labels(pkg, true) }}
-  </div>
-{% endmacro %}
-
-{% macro card_identity(pkg, mark_as_main=false) %}
-  <h3>
-    <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
-      {{- pkg.name -}}
-    </a>
-  </h3>
-
-  {% if pkg.author and (pkg.author | length) > 0 %}
-    <p class="authors">by
-    {% for author in pkg.author -%}
-      {% set q = searchQueryFor('author', author) %}
-      <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
-    {%- endfor %}
-    </p>
   {% endif %}
 {% endmacro %}

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -64,7 +64,7 @@
       {{ installs(pkg.installed, true) }}
       {{ stars(pkg.stars, true) }}
     </ul>
-    {{ labels(pkg, true, pkg.platform_statement) }}
+    {{ compact_card_footer(pkg) }}
   </div>
 {% endmacro %}
 
@@ -92,6 +92,18 @@
 
     {{ labels(pkg, true) }}
   </div>
+{% endmacro %}
+
+{% macro compact_card_footer(pkg) %}
+  {% if pkg.platform_statement or (pkg.labels and (pkg.labels | length) > 0) %}
+    {% set separator_count = (pkg.platform_statement | replace('/', '//') | length) - (pkg.platform_statement | length) %}
+    <div class="card-footer{{ ' card-footer-enumeration' if separator_count >= 2 }}">
+      {% if pkg.platform_statement %}
+        <div class="platform-statement">{{ pkg.platform_statement }}</div>
+      {% endif %}
+      {{ labels(pkg, true) }}
+    </div>
+  {% endif %}
 {% endmacro %}
 
 {% macro card_identity(pkg, mark_as_main=false) %}
@@ -137,7 +149,7 @@
   {% endif %}
 {% endmacro %}
 
-{% macro labels(pkg, with_icons=false, platform_statement='') %}
+{% macro labels(pkg, with_icons=false) %}
   {% set label_buttons -%}
     {%- for label in pkg.labels %}
       {% set q = searchQueryFor('label', label) %}
@@ -182,27 +194,9 @@
     {%- endfor -%}
   {%- endset %}
 
-  {% set buttons -%}
-    {%- if platform_statement -%}
-      {% set separator_count = (platform_statement | replace('/', '//') | length) - (platform_statement | length) %}
-      <li class="platform-statement-wrap{{ ' platform-statement-wrap-enumeration' if separator_count >= 2 }}">
-        <span class="platform-statement">{{ platform_statement }}</span>
-      </li>
-      {%- if label_buttons | trim -%}
-        <li class="package-labels-wrap">
-          <ul class="package-labels">
-            {{ label_buttons | safe }}
-          </ul>
-        </li>
-      {%- endif -%}
-    {%- else -%}
-      {{ label_buttons | safe }}
-    {%- endif -%}
-  {%- endset %}
-
-  {% if buttons | trim %}
+  {% if label_buttons | trim %}
     <ul class="button-group labels">
-      {{ buttons | safe }}
+      {{ label_buttons | safe }}
     </ul>
   {% endif %}
 {% endmacro %}

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -150,23 +150,32 @@
   {% endif %}
 {% endmacro %}
 
-{% macro card(pkg, mark_as_main=false, platform_in_labels=false) %}
-  <div class="card{{ ' dimmed' if pkg.outdated }}">
+{% macro compact_card(pkg, mark_as_main=false) %}
+  <div class="card card-compact{{ ' dimmed' if pkg.outdated }}">
     <div class="card-heading">
-      <h3>
-        <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
-          {{- pkg.name -}}
-        </a>
-      </h3>
+      {{ card_identity(pkg, mark_as_main) }}
+    </div>
 
-      {% if pkg.author and (pkg.author | length) > 0 %}
-        <p class="authors">by
-        {% for author in pkg.author -%}
-          {% set q = searchQueryFor('author', author) %}
-          <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
-        {%- endfor %}
-        </p>
-      {% endif %}
+    <ul class="stats">
+      {{ installs(pkg.installed, true) }}
+      {{ stars(pkg.stars, true) }}
+    </ul>
+    {{ labels(pkg, true, pkg.platform_statement) }}
+  </div>
+{% endmacro %}
+
+{% macro search_result_card(pkg, mark_as_main=false) %}
+  <div class="card card-result{{ ' dimmed' if pkg.outdated }}">
+    <div class="card-heading">
+      <div>
+        {{ card_identity(pkg, mark_as_main) }}
+      </div>
+
+      <ul class="stats">
+        {{ installs(pkg.installed, true) }}
+        {{ stars(pkg.stars, true) }}
+        {{ platforms(pkg.platform_statement) }}
+      </ul>
     </div>
 
     {% if pkg.description %}
@@ -175,14 +184,23 @@
       </p>
     {% endif %}
 
-    <ul class="stats">
-      {{ installs(pkg.installed, true) }}
-      {{ stars(pkg.stars, true) }}
-      {% if not platform_in_labels %}
-        {{ platforms(pkg.platform_statement) }}
-      {% endif %}
-    </ul>
-    {% set platform_label = pkg.platform_statement if platform_in_labels else '' %}
-    {{ labels(pkg, true, platform_label) }}
+    {{ labels(pkg, true) }}
   </div>
+{% endmacro %}
+
+{% macro card_identity(pkg, mark_as_main=false) %}
+  <h3>
+    <a {{ "id=main-content" if mark_as_main }} href="/packages/{{ pkg.name | urlencode }}">
+      {{- pkg.name -}}
+    </a>
+  </h3>
+
+  {% if pkg.author and (pkg.author | length) > 0 %}
+    <p class="authors">by
+    {% for author in pkg.author -%}
+      {% set q = searchQueryFor('author', author) %}
+      <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
+    {%- endfor %}
+    </p>
+  {% endif %}
 {% endmacro %}

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -184,7 +184,7 @@
     {%- if platform_statement -%}
       {% set separator_count = (platform_statement | replace('/', '//') | length) - (platform_statement | length) %}
       <li class="platform-statement-wrap{{ ' platform-statement-wrap-enumeration' if separator_count >= 2 }}">
-        <span class="button label platform-statement">{{ platform_statement }}</span>
+        <span class="platform-statement">{{ platform_statement }}</span>
       </li>
       {%- if label_buttons | trim -%}
         <li class="package-labels-wrap">

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -75,11 +75,13 @@
         {{ card_identity(pkg, mark_as_main) }}
       </div>
 
-      <ul class="stats">
-        {{ installs(pkg.installed, true) }}
-        {{ stars(pkg.stars, true) }}
-        {{ platforms(pkg.platform_statement) }}
-      </ul>
+      <div class="card-meta">
+        <ul class="stats">
+          {{ installs(pkg.installed, true) }}
+          {{ stars(pkg.stars, true) }}
+        </ul>
+        <div class="platforms">{{ pkg.platform_statement }}</div>
+      </div>
     </div>
 
     {% if pkg.description %}

--- a/_includes/templates.njk
+++ b/_includes/templates.njk
@@ -1,19 +1,25 @@
 {% import "packages/macros.njk" as pack %}
 {% import "util/macros.njk" as util %}
 
-{# template used by JS to render cards #}
-<template id="package-card">
-  {{ pack.card({
-    "name": "placeholder-name",
-    "description": "placeholder-description",
-    "author": "placeholder-author",
-    "stars": 666,
-    "installed": 999,
-    "archived_at": "1970-01-01 00:00:00",
-    "platforms": [],
-    "labels": ["foo"],
-    "permalink": "placeholder-permalink"
-  }) }}
+{# templates used by JS to render cards #}
+{% set placeholder_pkg = {
+  "name": "placeholder-name",
+  "description": "placeholder-description",
+  "author": "placeholder-author",
+  "stars": 666,
+  "installed": 999,
+  "archived_at": "1970-01-01 00:00:00",
+  "platforms": [],
+  "labels": ["foo"],
+  "permalink": "placeholder-permalink"
+} %}
+
+<template id="package-card-compact">
+  {{ pack.compact_card(placeholder_pkg) }}
+</template>
+
+<template id="package-card-result">
+  {{ pack.search_result_card(placeholder_pkg) }}
 </template>
 
 <template id="clipboard-button">

--- a/_includes/templates.njk
+++ b/_includes/templates.njk
@@ -10,6 +10,7 @@
   "installed": 999,
   "archived_at": "1970-01-01 00:00:00",
   "platforms": [],
+  "platform_statement": "placeholder-platform",
   "labels": ["foo"],
   "permalink": "placeholder-permalink"
 } %}

--- a/index.njk
+++ b/index.njk
@@ -23,7 +23,7 @@ date: Last Modified
   <ul class="grid">
     {% for pkg in collections.newest_packages %}
       <li>
-        {{ pack.card(pkg, loop.index0 == 0, true) }}
+        {{ pack.compact_card(pkg, loop.index0 == 0) }}
       </li>
     {% endfor %}
   </ul>
@@ -36,7 +36,7 @@ date: Last Modified
   <ul class="grid">
     {% for pkg in collections.updated_packages %}
       <li>
-        {{ pack.card(pkg, false, true) }}
+        {{ pack.compact_card(pkg) }}
       </li>
     {% endfor %}
   </ul>

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -196,7 +196,7 @@ export class Card {
       }
 
       const span = document.createElement('span')
-      span.classList.add('button', 'label', 'platform-statement')
+      span.classList.add('platform-statement')
       span.textContent = label
       li.appendChild(span)
 

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -181,6 +181,7 @@ export class Card {
       : ''
 
     if (!label) {
+      this.clone.querySelector('.card-meta .platforms')?.remove()
       return
     }
 
@@ -204,19 +205,13 @@ export class Card {
       return li
     }
 
-    const stats = this.clone.querySelector('ul.stats')
-    if (!stats) {
+    const platforms = this.clone.querySelector('.card-meta .platforms')
+    if (!platforms) {
       return
     }
-    let li = stats.querySelector('.platforms')
-    if (!li) {
-      li = document.createElement('li')
-      li.classList.add('platforms')
-      stats.appendChild(li)
-    }
-    li.textContent = label
+    platforms.textContent = label
 
-    return li
+    return platforms
   }
 
   countPlatformSeparators(label) {

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -38,7 +38,7 @@ export class Card {
     // clear the placeholder then fill with data
     labels.innerHTML = ''
     this.platforms()
-    this.labels(this.labelParent(labels))
+    this.labels(labels)
     this.stats()
 
     return this.clone
@@ -182,27 +182,21 @@ export class Card {
 
     if (!label) {
       this.clone.querySelector('.card-meta .platforms')?.remove()
+      this.clone.querySelector('.card-footer .platform-statement')?.remove()
       return
     }
 
     if (this.compact) {
-      const labels = this.clone.querySelector('ul.labels')
-      if (!labels) {
+      const platformStatement = this.clone.querySelector('.card-footer .platform-statement')
+      if (!platformStatement) {
         return
       }
-      const li = document.createElement('li')
-      li.classList.add('platform-statement-wrap')
-      if (this.countPlatformSeparators(label) >= 2) {
-        li.classList.add('platform-statement-wrap-enumeration')
-      }
-
-      const span = document.createElement('span')
-      span.classList.add('platform-statement')
-      span.textContent = label
-      li.appendChild(span)
-
-      labels.insertBefore(li, labels.firstChild)
-      return li
+      platformStatement.textContent = label
+      platformStatement.closest('.card-footer')?.classList.toggle(
+        'card-footer-enumeration',
+        this.countPlatformSeparators(label) >= 2,
+      )
+      return platformStatement
     }
 
     const platforms = this.clone.querySelector('.card-meta .platforms')
@@ -216,22 +210,6 @@ export class Card {
 
   countPlatformSeparators(label) {
     return label.split('/').length - 1
-  }
-
-  labelParent(parent) {
-    if (!this.compact || this.pkg.labels.length < 1 || !this.pkg.platform_statement?.trim()) {
-      return parent
-    }
-
-    const li = document.createElement('li')
-    li.classList.add('package-labels-wrap')
-
-    const nested = document.createElement('ul')
-    nested.classList.add('package-labels')
-    li.appendChild(nested)
-    parent.appendChild(li)
-
-    return nested
   }
 
   labels(parent) {

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -8,7 +8,8 @@ export class Card {
     this.pkg = data
     this.compact = compact === 'compact'
 
-    const template = document.querySelector('template#package-card')
+    const templateId = this.compact ? 'package-card-compact' : 'package-card-result'
+    const template = document.querySelector(`template#${templateId}`)
     this.clone = template.content.cloneNode(true)
     this.formatter = new Intl.NumberFormat('en', { notation: 'compact' })
   }
@@ -25,10 +26,12 @@ export class Card {
     this.authors(this.clone.querySelector('p.authors'))
 
     const descr_el = this.clone.querySelector('p.description')
-    if (this.compact || !this.pkg.description) {
-      descr_el.remove()
-    } else {
-      descr_el.innerHTML = this.pkg.description
+    if (descr_el) {
+      if (!this.pkg.description) {
+        descr_el.remove()
+      } else {
+        descr_el.innerHTML = this.pkg.description
+      }
     }
 
     const labels = this.clone.querySelector('ul.labels')
@@ -37,21 +40,8 @@ export class Card {
     this.platforms()
     this.labels(this.labelParent(labels))
     this.stats()
-    this.positionStats()
 
     return this.clone
-  }
-
-  positionStats() {
-    if (this.compact) {
-      return
-    }
-
-    const heading = this.clone.querySelector('.card-heading')
-    const stats = this.clone.querySelector('ul.stats')
-    if (heading && stats) {
-      heading.appendChild(stats)
-    }
   }
 
   insertDebugComment(cardRoot) {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -197,14 +197,16 @@ section[name="labels"] .grid {
   .authors {
     margin-bottom: 14px;
   }
-  .description {
-    font-size: 1rem;
-    max-width: calc(var(--max-line) * 5/6);
-    padding: 0;
-    margin: 0;
-  }
   .labels {
     justify-content: flex-start;
     margin-top: 21px;  /* usually collapses with margin-bottom from .description */
   }
+}
+
+.card-result .description,
+section[name="libraries"] .card .description {
+  font-size: 1rem;
+  max-width: calc(var(--max-line) * 5/6);
+  padding: 0;
+  margin: 0;
 }

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -140,40 +140,31 @@ section[name="labels"] .grid {
     gap: 0;
   }
 
+  .card-footer {
+    display: grid;
+    font-size: 13px;
+    grid-template-columns: max-content minmax(0, 1fr);
+    align-items: end;
+    column-gap: 7px;
+
+    &.card-footer-enumeration {
+      grid-template-columns: 1fr;
+      row-gap: 10px;
+    }
+  }
+
+  .card-footer:not(:has(.platform-statement)),
+  .card-footer:not(:has(.labels)) {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .platform-statement {
+    line-height: 22px;
+  }
+
   .labels {
     justify-content: flex-end;
-    &:has(> .platform-statement-wrap):has(> .package-labels-wrap) {
-      display: grid;
-      grid-template-columns: max-content minmax(0, 1fr);
-      align-items: end;
-      column-gap: 7px;
-
-      &:has(> .platform-statement-wrap-enumeration) {
-        grid-template-columns: 1fr;
-        row-gap: 10px;
-      }
-    }
-    .platform-statement-wrap {
-      line-height: 22px;
-    }
-    .platform-statement {
-      display: block;
-      line-height: inherit;
-    }
-    .package-labels-wrap {
-      justify-self: end;
-      max-width: 100%;
-    }
-    .package-labels {
-      display: flex;
-      gap: 7px;
-      justify-content: flex-end;
-      align-items: end;
-      flex-wrap: wrap;
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
   }
 }
 

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -52,31 +52,9 @@ section[name="labels"] .grid {
   transition: outline .1s ease-in-out, background .1s;
   overflow: hidden;
 
-  .grid & {
-    /* stretch cards vertically across the grid cells */
-    display: flex;
-    flex-direction: column;
-  }
-
   &:has(h3 a:hover),
   &:has(:focus-visible) {
     outline: 2px solid var(--orange-1);
-  }
-
-  .card-heading {
-    padding-right: 3.2em;
-  }
-
-  .grid & .card-heading {
-    flex: 1; /* push other content to the end of the card */
-  }
-
-  .authors {
-    padding-top: 0;
-    margin-bottom: 16px;
-  }
-  &:has(.stats .warning) .card-heading {
-    padding-right: 4.8em;
   }
 
   h3 {
@@ -95,21 +73,18 @@ section[name="labels"] .grid {
     }
   }
 
+  .authors {
+    padding-top: 0;
+  }
+
   > p:last-child {
     margin-bottom: 0;
   }
 
   .stats {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
     padding: 0;
     margin: 0;
     line-height: 18px;
-    position: absolute;
-    top: 18px;
-    right: 1rem;
-    gap: 0;
     font-size: 11px;
     background: inherit;
     color: var(--foreground-3);
@@ -121,13 +96,52 @@ section[name="labels"] .grid {
 
   .labels {
     font-size: 13px;
-    justify-content: flex-end;
     padding: 0;
     margin: 0;
     a {
       line-height: 20px;
       padding: 1px 6px;
     }
+  }
+
+  .button {
+    background: var(--background-2);
+    &:hover {
+      background: var(--background-3);
+    }
+  }
+}
+
+.card-compact {
+  .grid & {
+    /* stretch cards vertically across the grid cells */
+    display: flex;
+    flex-direction: column;
+  }
+
+  .card-heading {
+    flex: 1; /* push other content to the end of the card */
+    padding-right: 3.2em;
+  }
+  &:has(.stats .warning) .card-heading {
+    padding-right: 4.8em;
+  }
+  .authors {
+    margin-bottom: 16px;
+  }
+
+  .stats {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    position: absolute;
+    top: 18px;
+    right: 1rem;
+    gap: 0;
+  }
+
+  .labels {
+    justify-content: flex-end;
     &:has(> .platform-statement-wrap > .platform-statement):has(> .package-labels-wrap) {
       display: grid;
       grid-template-columns: max-content minmax(0, 1fr);
@@ -164,24 +178,22 @@ section[name="labels"] .grid {
       padding: 0;
     }
   }
+}
 
-  .list & .labels {
-    justify-content: flex-start;
-    margin-top: 21px;  /* usually collapses with margin-bottom from .description */
-  }
-
-  .list & .card-heading {
+.card-result {
+  .card-heading {
     padding-right: calc(min(38vw, 18rem) + 1rem);
     position: relative;
   }
 
-  .list & .stats {
+  .stats {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-end;
     align-items: flex-start;
     column-gap: 1em;
+    row-gap: 0;
     position: absolute;
     right: 0;
     top: 2px;
@@ -204,20 +216,17 @@ section[name="labels"] .grid {
     }
   }
 
-  .list & .authors {
+  .authors {
     margin-bottom: 14px;
   }
-  .list & .description {
+  .description {
     font-size: 1rem;
     max-width: calc(var(--max-line) * 5/6);
     padding: 0;
     margin: 0;
   }
-
-  .button {
-    background: var(--background-2);
-    &:hover {
-      background: var(--background-3);
-    }
+  .labels {
+    justify-content: flex-start;
+    margin-top: 21px;  /* usually collapses with margin-bottom from .description */
   }
 }

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -179,38 +179,28 @@ section[name="labels"] .grid {
 
 .card-result {
   .card-heading {
-    padding-right: calc(min(38vw, 18rem) + 1rem);
-    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, min(38vw, 18rem));
+    column-gap: 0.6rem;
+  }
+
+  .card-meta {
+    justify-self: end;
+    width: 100%;
+    font-size: 11px;
   }
 
   .stats {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
     justify-content: flex-end;
-    align-items: flex-start;
     column-gap: 1em;
-    row-gap: 0;
-    position: absolute;
-    right: 0;
-    top: 2px;
-    width: min(38vw, 18rem);
+  }
 
-    .stars {
-      order: 1;
-    }
-    .installs {
-      order: 2;
-    }
-    .platforms {
-      display: block;
-      flex-basis: 100%;
-      order: 3;
-      line-height: 1.25;
-      white-space: revert;
-      text-align: right;
-      margin-top: 4px;
-    }
+  .platforms {
+    line-height: 1.25;
+    margin-top: 4px;
+    text-align: right;
   }
 
   .authors {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -142,7 +142,7 @@ section[name="labels"] .grid {
 
   .labels {
     justify-content: flex-end;
-    &:has(> .platform-statement-wrap > .platform-statement):has(> .package-labels-wrap) {
+    &:has(> .platform-statement-wrap):has(> .package-labels-wrap) {
       display: grid;
       grid-template-columns: max-content minmax(0, 1fr);
       align-items: end;
@@ -153,15 +153,12 @@ section[name="labels"] .grid {
         row-gap: 10px;
       }
     }
+    .platform-statement-wrap {
+      line-height: 22px;
+    }
     .platform-statement {
-      background: transparent;
-      margin: 0;
-      padding: 0;
-      cursor: default;
-      white-space: revert;
-      &:hover {
-        background: transparent;
-      }
+      display: block;
+      line-height: inherit;
     }
     .package-labels-wrap {
       justify-self: end;

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -137,7 +137,7 @@ section[name="package"] > ul.stats .platforms {
 
 .labels {
   a,
-  span {
+  span:not(.platform-statement) {
     box-sizing: border-box;
     padding: 2px 6px;
     border: 1px solid transparent;

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -137,7 +137,7 @@ section[name="package"] > ul.stats .platforms {
 
 .labels {
   a,
-  span:not(.platform-statement) {
+  span {
     box-sizing: border-box;
     padding: 2px 6px;
     border: 1px solid transparent;


### PR DESCRIPTION
Separate compact landing-page package cards from search-result cards at
the template and CSS level. The two card variants share rendering helpers
but no longer rely on one layout that is patched differently per context.

