### PR TITLE
Redo library listing cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ _site/*
 .package_control_channel/
 channel.json
 logs.json
-libraries.json
 registry.json
 stats.json
 workspace.json

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ build:
 update-data:
 	# workspace from https://github.com/packagecontrol/thecrawl
 	curl -o workspace.json -L "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/workspace.json"
-	# libraries repository from https://github.com/packagecontrol/channel
-	curl -o libraries.json -L "https://raw.githubusercontent.com/packagecontrol/channel/refs/heads/main/repository.json"
 	# installation stats
 	curl -o stats.json -L "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/stats.json"
 	# thecrawl logs

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -319,8 +319,16 @@ function normalizedLib(pkg) {
     releases,
     latest_version: pkg.latest_version ?? latestReleaseVersion(releases),
     platforms,
-    platform_statement: util.computePlatformStatement(platforms),
+    platform_statement: libraryPlatformStatement(platforms),
   }
+}
+
+function libraryPlatformStatement(platforms) {
+  const statement = util.computePlatformStatement(platforms)
+  if (!statement || /^(Only|Not)\b/.test(statement)) {
+    return statement
+  }
+  return `Only for: ${statement}`
 }
 
 function latestReleaseVersion(releases) {

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -555,6 +555,7 @@ export default function (eleventyConfig) {
     return Object.values(workspace.libraries)
       .filter(lib => !lib.removed)
       .map(normalizedLib)
+      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
   })
 
   eleventyConfig.addGlobalData('built', () => {

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -308,29 +308,25 @@ function basePackage(pkg, stat) {
 }
 
 function normalizedLib(pkg) {
-  const allPlatforms = pkg.releases.flatMap((release) => {
-    if (typeof release.platforms !== 'undefined') {
-      return release.platforms
-    }
-    return []
-  })
-
-  const homepage = pkg.issues.replace('/issues', '')
-  let gh_path = ''
-  if (homepage.startsWith('https://github.com/')) {
-    gh_path = homepage.replace('https://github.com/', '')
-  }
+  const releases = pkg.releases ?? []
+  const platforms = util.computePlatformLabelsForSearch(releases).sort()
 
   return {
     name: pkg.name,
-    homepage: homepage,
-    path: gh_path,
-    author: util.cleanAuthors(pkg.author),
-    description: pkg.description,
-    releases: pkg.releases,
-    labels: [],
-    platforms: Array.from(new Set(allPlatforms)),
+    homepage: pkg.homepage ?? pkg.issues?.replace('/issues', '') ?? '',
+    author: util.cleanAuthors(pkg.author) ?? [],
+    description: translateEmojiCodes(pkg.description ?? ''),
+    releases,
+    latest_version: pkg.latest_version ?? latestReleaseVersion(releases),
+    platforms,
+    platform_statement: util.computePlatformStatement(platforms),
   }
+}
+
+function latestReleaseVersion(releases) {
+  return [...releases]
+    .sort((a, b) => new Date(b.date ?? '1970-01-01 00:00:00') - new Date(a.date ?? '1970-01-01 00:00:00'))
+    .find(release => release.version)?.version ?? ''
 }
 
 export default function (eleventyConfig) {
@@ -548,15 +544,9 @@ export default function (eleventyConfig) {
   })
 
   eleventyConfig.addCollection('libraries', () => {
-    const libraries = JSON.parse(fs.readFileSync('libraries.json', 'utf8'))
-    const dataset = util.collectPlatformDataset(libraries.libraries)
-    return libraries.libraries.map((lib) => {
-      const base = normalizedLib(lib)
-      return {
-        ...base,
-        platforms: util.simplifyPlatforms(dataset, base.platforms),
-      }
-    })
+    return Object.values(workspace.libraries)
+      .filter(lib => !lib.removed)
+      .map(normalizedLib)
   })
 
   eleventyConfig.addGlobalData('built', () => {

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -176,68 +176,6 @@ function platformTokenLabel(token) {
 }
 
 /**
- * Build the platform variant dataset over all libraries.
- * Input: array of libraries, each with releases[].platforms
- * Output: { windows: Set<string>, linux: Set<string>, osx: Set<string> }
- */
-export function collectPlatformDataset(libraries) {
-  const variantsByOs = {}
-  for (const lib of libraries || []) {
-    for (const rel of lib.releases || []) {
-      for (const p of rel.platforms || []) {
-        const m = /^(.+?)-(.+)$/i.exec(p)
-        if (m) {
-          const os = m[1].toLowerCase()
-          const label = m[2].toLowerCase()
-          if (!variantsByOs[os]) variantsByOs[os] = new Set()
-          variantsByOs[os].add(label)
-        }
-      }
-    }
-  }
-  return variantsByOs
-}
-
-/**
- * Simplify a library's platform list using the global dataset.
- * - If the library contains all known variants for an OS, collapse to base token (windows/linux/osx).
- * - If, after collapsing, it contains all three base tokens, return [] to hide labels.
- */
-export function simplifyPlatforms(dataset, platforms) {
-  const hasAll = (libSet, datasetSet) => {
-    for (const v of datasetSet)
-      if (!libSet.has(v))
-        return false
-    return true
-  }
-
-  const platformVariants = {}
-  for (const p of platforms) {
-    const m = /^(.+?)-(.+)$/i.exec(p)
-    if (m) {
-      const os = m[1].toLowerCase()
-      const variant = m[2].toLowerCase()
-      if (!platformVariants[os]) platformVariants[os] = new Set()
-      platformVariants[os].add(variant)
-    }
-  }
-
-  let result = new Set()
-  for (const [os, variants] of Object.entries(platformVariants)) {
-    if (hasAll(variants, dataset[os]))
-      result.add(os)
-    else
-      variants.forEach(variant => result.add(`${os}-${variant}`))
-  }
-
-  if (['windows', 'linux', 'osx'].every(os => result.has(os))) {
-    return []
-  }
-
-  return Array.from(result)
-}
-
-/**
  * Author can be string or array: convert to all arrays.
  */
 export function cleanAuthors(author) {
@@ -899,53 +837,6 @@ if (import.meta.vitest) {
         'three',
         'four',
       ])
-    })
-  })
-
-  describe('collectPlatformDataset + simplifyPlatforms (libraries)', () => {
-    const libraries = [
-      {
-        releases: [
-          { platforms: ['windows-x32', 'windows-x64'] },
-          { platforms: ['linux-x32'] },
-        ],
-      },
-      {
-        releases: [
-          { platforms: ['linux-x64'] },
-          { platforms: ['osx-x64'] },
-        ],
-      },
-    ]
-
-    it('collects global variant sets per OS', () => {
-      const ds = collectPlatformDataset(libraries)
-      expect(Array.from(ds.windows).sort()).toEqual(['x32', 'x64'])
-      expect(Array.from(ds.linux).sort()).toEqual(['x32', 'x64'])
-      expect(Array.from(ds.osx).sort()).toEqual(['x64'])
-    })
-
-    it('collapses to base OS only when all variants are present for that OS', () => {
-      const ds = collectPlatformDataset(libraries)
-
-      // Has both windows variants -> collapse to 'windows'
-      expect(simplifyPlatforms(ds, ['windows-x32', 'windows-x64'])).toEqual(['windows'])
-
-      // Missing one windows variant -> do not collapse
-      expect(simplifyPlatforms(ds, ['windows-x64'])).toEqual(['windows-x64'])
-
-      // Linux has x32 and x64 in dataset; this lib has both -> collapse
-      expect(simplifyPlatforms(ds, ['linux-x32', 'linux-x64'])).toEqual(['linux'])
-
-      // OSX dataset has only x64; having x64 means "all known" -> collapse
-      expect(simplifyPlatforms(ds, ['osx-x64'])).toEqual(['osx'])
-    })
-
-    it('hides labels when all three base OS tokens are present', () => {
-      const ds = collectPlatformDataset(libraries)
-      expect(simplifyPlatforms(ds, ['windows-x32', 'windows-x64', 'linux-x32', 'linux-x64', 'osx-x64']))
-        .toEqual([])
-      expect(simplifyPlatforms(ds, ['windows', 'linux', 'osx'])).toEqual([])
     })
   })
 

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -101,9 +101,12 @@ export function computePlatformStatement(platforms) {
     tokens.push({ kind: 'other', raw: token })
   })
 
-  const collapseOs = new Set()
+  const collapseOs = new Set(baseTokens)
   for (const [os, variants] of variantsByOs.entries()) {
-    if (variants.has('x32') && variants.has('x64')) {
+    if (os === 'windows' && variants.has('x64')) {
+      collapseOs.add(os)
+    }
+    if ((os === 'linux' || os === 'macos') && variants.has('x64') && variants.has('arm64')) {
       collapseOs.add(os)
     }
   }
@@ -761,12 +764,20 @@ if (import.meta.vitest) {
       [['macos', 'windows'], 'Not for Linux'],
       [['linux', 'windows'], 'Not for macOS'],
 
-      [['linux-x64', 'windows-x64', 'macos-x64'], 'Only on x64'],
+      [['linux-x64', 'windows-x64', 'macos-x64'], 'Linux‑x64\u00A0/ Windows\u00A0/ macOS‑x64'],
+      [['linux-arm64', 'linux-x64', 'macos-arm64', 'macos-x64', 'windows-x64'], ''],
 
-      [['linux-x32', 'linux-x64'], 'Only for Linux'],
-      [['linux-x32', 'linux-x64', 'windows'], 'Not for macOS'],
+      [['linux-x32', 'linux-x64'], 'Linux‑x32\u00A0/ Linux‑x64'],
+      [['linux-x32', 'linux-x64', 'windows'], 'Linux‑x32\u00A0/ Linux‑x64\u00A0/ Windows'],
 
-      [['windows-x64'], 'Only on Windows‑x64'],
+      [['windows-x64'], 'Only for Windows'],
+      [['windows-arm64'], 'Only on Windows‑arm64'],
+      [['windows-arm64', 'windows-x64'], 'Only for Windows'],
+      [['windows-x32', 'windows-x64'], 'Only for Windows'],
+      [['macos-arm64', 'macos-x64'], 'Only for macOS'],
+      [['linux-arm64', 'linux-x64'], 'Only for Linux'],
+      [['macos-x64'], 'Only on macOS‑x64'],
+      [['linux-x64'], 'Only on Linux‑x64'],
       [['linux-x32', 'windows-x32'], 'Linux‑x32\u00A0/ Windows‑x32'],
       [['linux-arm64'], 'Only on Linux‑arm64'],
     ])('computePlatformStatement(%j) -> %j', (input, expected) => {

--- a/libraries.njk
+++ b/libraries.njk
@@ -8,43 +8,44 @@ date: Last Modified
 {% import "util/macros.njk" as shared %}
 
 {% macro lib(pkg, mark_as_main=false) %}
-  <div class="card"
+  <div class="card card-result"
     data-name="{{ pkg.name | escape }}"
     data-author="{{ pkg.author | escape }}"
-    data-description="{{ pkg.description | escape }}">
+    data-description="{{ pkg.description | escape }}"
+    data-platforms="{{ pkg.platforms | join(',') | escape }}">
 
-    <h3>
-      <a {{ "id=main-content" if mark_as_main }} href="{{ pkg.homepage }}">
-        {{ pkg.name }}
-      </a>
-    </h3>
-
-    <p>by {% for author in pkg.author -%}
-      {{ author }}{{ ", " if not loop.last }}
-    {%- endfor %}</p>
-
-    <p class="description">
-      {{- pkg.description -}}
-    </p>
-
-    <ul class="button-group labels">
-      <li class="shield">
-        <img height="24" alt="Latest Python Package Index tag" src="{{ 'https://img.shields.io/pypi/v/' ~ pkg.name | replace('python-', '') ~ '.svg' }}">
-      </li>
-      {% if pkg.path %}
-        <li class="shield">
-          <img height="24" alt="Latest GitHub tag" src="{{ 'https://img.shields.io/github/tag/' ~ pkg.path ~ '.svg' }}">
-        </li>
-      {% endif %}
-      {% for platform in pkg.platforms %}
-        {% set q = util.searchQueryFor('platform', platform) %}
-        <li>
-          <a class="button platform platform-{{ platform }}" href="/libraries/?q={{ q }}">
-            {{ platform }}
+    <div class="card-heading">
+      <div>
+        <h3>
+          <a {{ "id=main-content" if mark_as_main }} href="{{ pkg.homepage }}">
+            {{ pkg.name }}
           </a>
-        </li>
-      {% endfor %}
-    </ul>
+        </h3>
+
+        {% if pkg.author and (pkg.author | length) > 0 %}
+          <p class="authors">by {% for author in pkg.author -%}
+            {{ author }}{{ ", " if not loop.last }}
+          {%- endfor %}</p>
+        {% endif %}
+      </div>
+
+      {% if pkg.latest_version or pkg.platform_statement %}
+        <div class="card-meta library-meta">
+          {% if pkg.latest_version %}
+            <span class="library-version">v{{ pkg.latest_version }}</span>
+          {% endif %}
+          {% if pkg.platform_statement %}
+            <div class="platforms">{{ pkg.platform_statement }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+
+    {% if pkg.description %}
+      <p class="description">
+        {{- pkg.description -}}
+      </p>
+    {% endif %}
   </div>
 {% endmacro %}
 

--- a/libraries.njk
+++ b/libraries.njk
@@ -29,14 +29,9 @@ date: Last Modified
         {% endif %}
       </div>
 
-      {% if pkg.latest_version or pkg.platform_statement %}
+      {% if pkg.latest_version %}
         <div class="card-meta library-meta">
-          {% if pkg.latest_version %}
-            <span class="library-version">v{{ pkg.latest_version }}</span>
-          {% endif %}
-          {% if pkg.platform_statement %}
-            <div class="platforms">{{ pkg.platform_statement }}</div>
-          {% endif %}
+          <span class="library-version">v{{ pkg.latest_version }}</span>
         </div>
       {% endif %}
     </div>
@@ -44,6 +39,12 @@ date: Last Modified
     {% if pkg.description %}
       <p class="description">
         {{- pkg.description -}}
+      </p>
+    {% endif %}
+
+    {% if pkg.platform_statement %}
+      <p class="library-platforms">
+        {{- pkg.platform_statement -}}
       </p>
     {% endif %}
   </div>

--- a/static/libs.js
+++ b/static/libs.js
@@ -8,29 +8,15 @@ import { customTokenizer } from './module/minisearch.js'
 
 const cards = document.querySelectorAll('[data-name]')
 const data = Array.from(cards, (card) => {
-  // Map class names like "platform-linux" back to plain platform identifiers
-  let platforms = new Set((function* () {
-    for (const el of card.querySelectorAll('.platform')) {
-      for (const cls of el.classList) {
-        if (cls.startsWith('platform-')) yield cls.slice('platform-'.length)
-      }
-    }
-  })())
-
-  // In Libraries, infer 'any' for untagged libs or those that collapsed
-  // to all three base OS (windows, linux, osx) so platform searches include them.
-  if (
-    platforms.size == 0
-    || ['windows', 'linux', 'osx'].every(x => platforms.has(x))
-  ) {
-    platforms = ['any']
-  }
+  const platforms = card.dataset.platforms
+    ? card.dataset.platforms.split(',').filter(Boolean)
+    : ['any']
 
   return {
     name: card.dataset.name,
     author: card.dataset.author,
     description: card.dataset.description,
-    platforms: Array.from(platforms),
+    platforms,
   }
 })
 
@@ -56,39 +42,3 @@ const search = new SimpleSearch(
   },
 )
 search.init()
-
-// Intercept clicks on platform buttons to run in-page search
-document.addEventListener('click', (event) => {
-  const target = event.target.closest('a')
-  if (!target) {
-    return
-  }
-  if (!target.classList.contains('platform')) {
-    return
-  }
-  const url = new URL(target.href, window.location.origin)
-  const q = url.searchParams.get('q')
-  if (!q) {
-    return
-  }
-  event.preventDefault()
-  event.stopPropagation()
-  // Apply the platform query immediately without full navigation
-  scrollUp()
-  search.applySearch(q, { updateHistory: true, updateInput: true })
-})
-
-function scrollUp(all_the_way = true) {
-  const target = all_the_way
-    ? document.forms.search
-    : document.querySelector('[data-list-target="counter"]')
-  if (!target) {
-    return
-  }
-  const rect = target.getBoundingClientRect()
-  const completelyAbove = rect.bottom < 0
-  const completelyBelow = rect.top > window.innerHeight
-  if (completelyAbove || completelyBelow) {
-    target.scrollIntoView()
-  }
-}

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -196,7 +196,6 @@ section[name="labels"] .grid {
 
   .library-meta {
     align-self: start;
-    font-size: 11px;
     text-align: right;
   }
 
@@ -216,6 +215,15 @@ section[name="labels"] .grid {
   .authors {
     margin-bottom: 14px;
   }
+
+  .library-platforms {
+    color: var(--foreground-2);
+    font-size: 11px;
+    line-height: 1.35;
+    margin-top: 18px;
+    margin-bottom: 0;
+  }
+
   .labels {
     justify-content: flex-start;
     margin-top: 21px;  /* usually collapses with margin-bottom from .description */

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -194,6 +194,25 @@ section[name="labels"] .grid {
     text-align: right;
   }
 
+  .library-meta {
+    align-self: start;
+    font-size: 11px;
+    text-align: right;
+  }
+
+  .library-version {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 3px;
+    margin-bottom: 5px;
+    background: var(--background-2);
+    color: var(--foreground-2);
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 1px;
+    line-height: 20px;
+  }
+
   .authors {
     margin-bottom: 14px;
   }
@@ -203,8 +222,7 @@ section[name="labels"] .grid {
   }
 }
 
-.card-result .description,
-section[name="libraries"] .card .description {
+.card-result .description {
   font-size: 1rem;
   max-width: calc(var(--max-line) * 5/6);
   padding: 0;


### PR DESCRIPTION
Render libraries from the workspace data so the listing uses current
versions, platform metadata, and descriptions.

Align library cards with search result cards, remove legacy shield and
platform tags, and show version and platform details in the card meta
area.

Fixes #373 